### PR TITLE
Add lightbox and mark specific images as no-lightbox

### DIFF
--- a/Document/0x02c-Acknowledgements.md
+++ b/Document/0x02c-Acknowledgements.md
@@ -73,7 +73,7 @@ MAS Advocates may contribute to discussions, provide feedback, and suggest impro
 
 ### NowSecure
 
-<img src="Images/Other/nowsecure-logo.png" style="width: 50%; border-radius: 5px" />
+<img src="Images/Other/nowsecure-logo.png" style="width: 50%; border-radius: 5px" class="no-lightbox"/>
 
 **We'd like to thank [NowSecure](https://www.nowsecure.com) for its exemplary contributions since 2022, which set a blueprint for other potential contributors wanting to push the project forward.** [Read more about their journey here.](../news/posts/2025-04-09-celebrating-3-years-advocate-nowsecure.md)
 
@@ -93,7 +93,7 @@ In the past, NowSecure has also contributed to the project and has donated the @
 
 ### Guardsquare
 
-<img src="Images/Other/guardsquare-logo.png" style="width: 50%; border-radius: 5px" />
+<img src="Images/Other/guardsquare-logo.png" style="width: 50%; border-radius: 5px" class="no-lightbox"/>
 
 **We'd like to thank [Guardsquare](https://www.guardsquare.com) for its outstanding contributions to the OWASP MAS project, culminating in achieving MAS Advocate status in 2025.** [Read more about their achievement here.](../news/posts/2025-05-23-new-advocate-guardsquare.md)
 

--- a/Document/index.md
+++ b/Document/index.md
@@ -5,7 +5,7 @@ hide:
 
 # OWASP MASTG
 
-<img src="../assets/mastg_cover.png" align="right" style="border-radius: 3px; margin: 3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="350px" />
+<img src="../assets/mastg_cover.png" align="right" style="border-radius: 3px; margin: 3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="350px" class="no-lightbox" />
 
 <a href="https://github.com/OWASP/owasp-mastg/">:material-github: GitHub Repo</a>
 

--- a/docs/checklists/index.md
+++ b/docs/checklists/index.md
@@ -7,7 +7,7 @@ search:
 
 # OWASP MAS Checklist
 
-<img src="../assets/mas_checklist.png" align="right" style="border-radius: 3px; margin-left: 5em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="550px" />
+<img src="../assets/mas_checklist.png" align="right" style="border-radius: 3px; margin-left: 5em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="550px" class="no-lightbox"/>
 
 The OWASP Mobile Application Security Checklist contains links to the MASTG test cases for each MASVS control.
 

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -6,7 +6,7 @@ hide:
 
 # &#128172; Connect with Us
 
-<img src="../../assets/logo_circle.png" width="150px" style="margin-left: 4em; margin-top: 0em;" align="right">
+<img src="../../assets/logo_circle.png" width="150px" style="margin-left: 4em; margin-top: 0em;" class="no-lightbox" align="right">
 
 You can follow and reach out to the OWASP MAS team in many ways.
 
@@ -31,7 +31,7 @@ If you'd like to contribute, take a look at our [Contributions page](contributin
 
 ## Carlos Holguera
 
-<img src="../../assets/carlos.jpg" width="150px" style="border-radius: 50%; margin-left: 4em;" align="right">
+<img src="../../assets/carlos.jpg" width="150px" style="border-radius: 50%; margin-left: 4em;" align="right" class="no-lightbox">
 
 Carlos is a mobile security research engineer who has gained many years of hands-on experience in the field of security testing for mobile apps and embedded systems such as automotive control units and IoT devices. He is passionate about reverse engineering and dynamic instrumentation of mobile apps and is continuously learning and sharing his knowledge.
 
@@ -46,7 +46,7 @@ Carlos is a mobile security research engineer who has gained many years of hands
 
 ## Sven Schleier
 
-<img src="../../assets/sven.jpg" width="150px" style="border-radius: 50%; margin-left: 4em;" align="right">
+<img src="../../assets/sven.jpg" width="150px" style="border-radius: 50%; margin-left: 4em;" align="right" class="no-lightbox">
 
 Sven is an experienced web and mobile penetration tester and assessed everything from historic Flash applications to progressive mobile apps. He is also a security engineer that supported many projects end-to-end during the SDLC to "build security in". He was speaking at local and international meetups and conferences and is conducting hands-on workshops about web application and mobile app security.
 

--- a/docs/donate.md
+++ b/docs/donate.md
@@ -10,7 +10,7 @@ We thank our donators for providing the funds to support us on our project activ
 **The OWASP Foundation is very grateful for the support by the individuals and organizations listed. However please note, the OWASP Foundation is strictly vendor neutral and does not endorse any of its supporters. Donations do not influence the content of the MASVS or MASTG in any way.**
 
 <br><br>
-<img style="border-radius: 15px;" src="https://raw.githubusercontent.com/OWASP/owasp-mastg/master/Document/Images/Donators/donators.png"/>
+<img style="border-radius: 15px;" src="https://raw.githubusercontent.com/OWASP/owasp-mastg/master/Document/Images/Donators/donators.png" class="no-lightbox"/>
 <br><br>
 
 While both the MASVS and the MASTG are created and maintained by the community on a voluntary basis, sometimes a little bit of outside help is required.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hide:
 </div>
 
 <center>
-<img style="padding: 10px; max-width: 250px" src="assets/logo_circle.png" />
+<img style="padding: 10px; max-width: 250px" src="assets/logo_circle.png"  class="no-lightbox"/>
 </center>
 
 </div>
@@ -75,7 +75,7 @@ hide:
 The OWASP MASVS and MASTG are trusted by the following platform providers and standardization, governmental and educational institutions. [Learn more](MASTG/0x02b-MASVS-MASTG-Adoption.md).
 
 <a href="MASTG/0x02b-MASVS-MASTG-Adoption/">
-<img style="border-radius: 1em;" src="assets/trusted-by-logos.png"/>
+<img style="border-radius: 1em;" src="assets/trusted-by-logos.png" class="no-lightbox"/>
 </a>
 
 <br>
@@ -90,10 +90,10 @@ The OWASP MASVS and MASTG are trusted by the following platform providers and st
 
 <div style="display: flex; flex-direction: column; align-items: center; gap: 1em; min-width: 300px;">
 <a href="MASTG/0x02c-Acknowledgements/#our-mas-advocates">
-<img src="https://raw.githubusercontent.com/OWASP/owasp-mastg/master/Document/Images/Other/nowsecure-logo.png" style="width: 250px;" />
+<img src="https://raw.githubusercontent.com/OWASP/owasp-mastg/master/Document/Images/Other/nowsecure-logo.png" style="width: 250px;" class="no-lightbox"/>
 </a>
 <a href="MASTG/0x02c-Acknowledgements/#our-mas-advocates">
-<img src="assets/guardsquare-logo.png" style="width: 250px; border-radius: 5px;" />
+<img src="assets/guardsquare-logo.png" style="width: 250px; border-radius: 5px;" class="no-lightbox"/>
 </a>
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hide:
 </div>
 
 <center>
-<img style="padding: 10px; max-width: 250px" src="assets/logo_circle.png"  class="no-lightbox"/>
+<img style="padding: 10px; max-width: 250px" src="assets/logo_circle.png" class="no-lightbox"/>
 </center>
 
 </div>

--- a/docs/javascripts/lightbox.js
+++ b/docs/javascripts/lightbox.js
@@ -1,0 +1,44 @@
+function updateImageClasses() {
+
+  const isMobile = window.matchMedia("(max-width: 768px)").matches;
+  document.querySelectorAll("a.glightbox, a.no-click-image").forEach(function (el) {
+      if (isMobile) {
+        el.classList.remove("glightbox");
+        el.classList.add("no-click-image");
+      } else {
+        el.classList.add("glightbox");
+        el.classList.remove("no-click-image");
+      }
+    });
+
+  if(lightbox){
+    lightbox.destroy()
+    lightbox.reload()
+  }
+
+  const allLightboxTriggers = document.querySelectorAll('.glightbox')
+  if (allLightboxTriggers) {
+    allLightboxTriggers.forEach(function(trigger) {
+      trigger.addEventListener('click', function(e) {
+        const isMobile = window.matchMedia("(max-width: 768px)").matches
+        console.log("clicky", isMobile)
+        e.preventDefault()
+        let targetHref = this.getAttribute('href')
+        if(isMobile) {
+          e.stopPropagation()
+          return true;
+        }
+        lightbox.setElements([{'href': targetHref}])
+        lightbox.open()
+      })
+    })
+  }
+}
+
+// On MkDocs page load
+document$.subscribe(() => {
+  updateImageClasses();
+});
+
+// On window resize
+$(window).on("resize", updateImageClasses);

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -97,6 +97,15 @@
 }
 
 
+.glightbox-button-hidden {
+    display: none;
+}
+/* Hide mouse-click for images when screen is too small */
+a.no-click-image {
+  cursor: default;
+  pointer-events: none;
+}
+
 /* Wider space for pages */
 .md-grid {
   max-width: 90%;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -268,6 +268,7 @@ extra_javascript:
   - javascripts/filter_tests.js
   - javascripts/navigation.js
   - javascripts/tags.js
+  - javascripts/lightbox.js
 plugins:
   # Uses https://github.com/mkdocs/mkdocs-redirects getting the redirects map from src/scripts/generate_redirects.py
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -274,6 +274,9 @@ plugins:
   - awesome-pages
   # - privacy
   # - offline
+  - glightbox:
+      skip_classes:
+        - no-lightbox
   - blog:
   # https://squidfunk.github.io/mkdocs-material/plugins/blog/
       blog_dir: news

--- a/src/scripts/requirements.txt
+++ b/src/scripts/requirements.txt
@@ -11,3 +11,4 @@ lxml==5.4.0
 bs4==0.0.2
 openpyxl==3.1.5
 Pillow==11.2.1
+mkdocs-glightbox==0.4.0

--- a/weaknesses/index.md
+++ b/weaknesses/index.md
@@ -8,7 +8,7 @@ title: Mobile Application Security Weakness Enumeration (MASWE)
     The Mobile Application Security Weakness Enumeration (MASWE) is a list of common security and privacy weaknesses in mobile applications. It is intended to be used as a reference for developers, security researchers, and security professionals. It acts as the bridge between the [MASVS](https://mas.owasp.org/MASVS) and the [MASTG](https://mas.owasp.org/MASTG).
 
     <center>
-    <img src="../assets/maswe-overview.png" style="width: 50%; border-radius: 5px; margin: 2em" />
+    <img src="../assets/maswe-overview.png" style="width: 50%; border-radius: 5px; margin: 2em" class="no-lightbox"/>
     </center>
 
     For its definition we draw inspiration from the [Common Weakness Enumeration (CWE)](https://cwe.mitre.org/), which is a community-developed list of common software security weaknesses. The MASWE is intended to be a **complementary list to the CWE**, focusing specifically on security weaknesses in mobile applications.


### PR DESCRIPTION
## Add lightbox plugin

* Uses https://blueswen.github.io/mkdocs-glightbox
* Custom css class for disabling lightbox: `no-lightbox`

## Marked various images as no-lightbox

* It's on by default, but doesn't make sense for many of the 'website' images
* It will also automatically disable itself if the image is a link