### PR TITLE
Add placeholder demo and test for storing sensitive data using EncryptedSharedPreferences

### DIFF
--- a/demos/android/MASVS-CRYPTO/MASTG-DEMO-0060/MASTG-DEMO-0060.md
+++ b/demos/android/MASVS-CRYPTO/MASTG-DEMO-0060/MASTG-DEMO-0060.md
@@ -1,0 +1,11 @@
+---
+platform: android
+title: App Writing Sensitive Data to Sandbox using EncryptedSharedPreferences
+id: MASTG-DEMO-0060
+code: [kotlin]
+test: MASTG-TEST-0287
+kind: pass
+status: placeholder
+note: This demo shows how to store sensitive data securely in the app sandbox using the EncryptedSharedPreferences class.
+---
+

--- a/tests-beta/android/MASVS-CRYPTO/MASTG-TEST-0287.md
+++ b/tests-beta/android/MASVS-CRYPTO/MASTG-TEST-0287.md
@@ -1,0 +1,11 @@
+---
+title: Sensitive Data Stored Unencrypted via the SharedPreferences API to the App Sandbox
+platform: android
+id: MASTG-TEST-0287
+type: [static, dynamic]
+weakness: MASWE-0006
+best-practices: []
+profiles: [L1, L2]
+status: placeholder
+note: This test checks if the app is using the SharedPreferences API to store sensitive data (e.g. user credentials, tokens) in an unencrypted format within the app's sandbox. This includes checking for the use of `SharedPreferences` without encryption as well as not using `EncryptedSharedPreferences` or similar secure storage mechanisms.
+---


### PR DESCRIPTION
Introduce a demo and a corresponding test to validate the secure storage of sensitive data in the app sandbox using the EncryptedSharedPreferences class. The demo illustrates best practices, while the test ensures compliance with secure storage guidelines.