### PR TITLE
Add demo for securely storing sensitive data using EncryptedSharedPreferences

### DIFF
--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/MASTG-DEMO-0060.md
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/MASTG-DEMO-0060.md
@@ -5,7 +5,58 @@ id: MASTG-DEMO-0060
 code: [kotlin]
 test: MASTG-TEST-0287
 kind: pass
-status: placeholder
 note: This demo shows how to store sensitive data securely in the app sandbox using the EncryptedSharedPreferences class.
 ---
 
+### Sample
+
+The following Kotlin code demonstrates how to securely store sensitive data (such as a password and API key) in the app sandbox using `EncryptedSharedPreferences`:
+
+{{ MastgTest.kt }}
+
+### Steps
+
+1. Install the app on a device (@MASTG-TECH-0005)
+2. Make sure you have @MASTG-TOOL-0001 installed on your machine and the frida-server running on the device
+3. Run `run.sh` to spawn the app with Frida
+4. Click the **Start** button
+5. Stop the script by pressing `Ctrl+C` and/or `q` to quit the Frida CLI
+
+{{ hooks.js # run.sh }}
+
+### Observation
+
+The output shows all instances of strings written using `EncryptedSharedPreferences` via `SharedPreferences` that were found at runtime. A backtrace is also provided to help identify the location in the code.
+
+{{ output.json }}
+
+### Evaluation
+
+This test **passes** because sensitive data is stored using `EncryptedSharedPreferences`, which encrypts both keys and values at rest. Even if an attacker gains access to the app's sandbox, the data remains protected and unreadable without the app's encryption keys.
+
+For example, to confirm this, run the following command:
+
+```sh
+adb shell cat /data/data/org.owasp.mastestapp/shared_prefs/MasSharedPref_Sensitive_Data.xml
+```
+
+Which returns:
+
+```xml
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<map>
+    <set name="preSharedKeys">
+        <string>gJXS9EwpuzK8U1TOgfplwfKEVngCE2D5FNBQWvNmuHHbigmTCabsA=</string>
+        <string>MIIEvAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBALfX7kbfFv3pc3JjOHQ=</string>
+    </set>
+    <string name="EncryptedAWSKey">pxEiQP+VKpawU4B4fLoxk6v85z5UKXsYAq64lwUKL3ZBu3y7Ab+qTyGlXrZcqKzW&#10;    </string>
+    <string name="__androidx_security_crypto_encrypted_prefs_key_keyset__">12a901eca02edb449ca6eff4c578f9a952c35a...</string>
+    <string name="AUL3Px4pwXPb6gLG5OX48h5nKeBAKRGf616ybiTzcYI=">ARuZb6AqdljdJ7L9CUayBeSEC0SliQ2AoW3V+9oirzIc0mJdfGUfZY2kM7KGGhHt/5PLe6rNoAHVEFxSckoErV8RWQcGCTb6uif0pUU=</string>
+    <string name="AUL3Px64PpFLIrZk+ZdSewnmsZAM5xjKhDRTOBb/0UlYMw==">ARuZb6DkkPCUF6z5qtDS83z+Toe60jSAYf+XM/n4tSPeICmlUfV5MFqNuO5ONIxOTdTgNs18+ET+fIrBOQ9iiLhyGokjWvsFp6MiceP//fXWIIfCQJGgEAFfGiOLO+7FDqucemQP0laysVWvahhHYcw6Wbk424Uqo2lxFSe/kTfZI+/QJ0mCKOGxXEfaHQAsUqdOqpKxppsMxO3hzKDc5fN3ew1QX3E=</string>
+    <string name="__androidx_security_crypto_encrypted_prefs_value_keyset__">128801630b7bbf51cb1c0dbd7b76d881ccd9...</string>
+    <string name="GitHubToken">FtZv5Zl5ULTonWZFr9vH1q8vuH9VtZAe0qQLZS4GhwGjXmLU1G+U+GsghU2JzeRSdXKfo+MeV2uZ&#10;/EJ5t0bGpA==&#10;    </string>
+    <string name="AUL3Px45SzM2kV7WxPAT6C/+pC+qCdFnO+cjU/2Cv5vVZa4F">ARuZb6DQ3VIUnc+1gD3isLliTFCSh8SKiq+fbWUYEKCZ7/qjnP7ukVckwr2NEdm1i4qXCw/njxBsgowH/g==</string>
+</map>
+```
+
+The actual values are not visible in plain text, confirming that encryption is applied.

--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/MastgTest.kt
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/MastgTest.kt
@@ -1,0 +1,42 @@
+package org.owasp.mastestapp
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+class MastgTest(private val context: Context) {
+    private val awsKey = "AKIAIOSFODNN7EXAMPLE"
+    private val githubToken = "ghp_1234567890abcdefghijklmnOPQRSTUV"
+    private val preSharedKeys = setOf(
+        "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBALfX7kbfFv3pc3JjOHQ=",
+        "gJXS9EwpuzK8U1TOgfplwfKEVngCE2D5FNBQWvNmuHHbigmTCabsA="
+    )
+    private val sharedPrefsName = "MasSharedPref_Sensitive_Data"
+
+    fun mastgTest(): String {
+        return try {
+            val masterKey = MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+
+            val encryptedPrefs = EncryptedSharedPreferences.create(
+                context,
+                sharedPrefsName,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+
+            encryptedPrefs.edit {
+                putString("EncryptedAWSKey", awsKey)
+                putString("GitHubToken", githubToken)
+                putStringSet("preSharedKeys", preSharedKeys)
+            }
+
+            "Sensitive data has been written and deleted in the sandbox."
+        } catch (e: Exception) {
+            "Error during MastgTest: ${e.message ?: "Unknown error"}"
+        }
+    }
+}

--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/hooks.js
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/hooks.js
@@ -1,0 +1,67 @@
+var target = {
+  category: "STORAGE",
+  demo: "0059",
+  hooks: [
+    {
+      class: "android.app.SharedPreferencesImpl$EditorImpl",
+      methods: [
+        "putString",
+        "putStringSet"
+      ]
+    },
+    {
+      class: "javax.crypto.Cipher",
+      methods: [
+        "getInstance",
+        "doFinal",
+        "init",
+        "update",
+      ]
+    },
+    {
+      class: "java.security.KeyStore",
+      methods: [
+        // "getInstance",
+        "setEntry",
+        "getEntry"
+      ]
+    },
+    {
+      class: "javax.crypto.KeyGenerator",
+      methods: [
+        "getInstance",
+        // "init",
+        "generateKey"
+      ]
+    },
+    {
+      class: "android.util.Base64",
+      methods: [
+        "encodeToString",
+        // "encode",
+        "decode"
+      ]
+    },
+    {
+      class: "com.google.crypto.tink.DeterministicAead",
+      methods: [
+        "encryptDeterministically",
+        "decryptDeterministically"
+      ]
+    },
+    {
+      class: "com.google.crypto.tink.subtle.Base64",
+      methods: [
+        "encode",
+        "decode"
+      ]
+    },
+    {
+      class: "androidx.security.crypto.EncryptedSharedPreferences",
+      methods: [
+        "create",
+        "edit"
+      ]
+    }
+  ]
+}

--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/output.json
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/output.json
@@ -1,0 +1,58 @@
+{
+  "id": "418e8d44-57b1-45bc-bbd8-0d0e42a587b2",
+  "category": "STORAGE",
+  "time": "2025-07-19T15:52:04.880Z",
+  "class": "com.google.crypto.tink.subtle.Base64",
+  "method": "encode",
+  "stackTrace": [
+    "com.google.crypto.tink.subtle.Base64.encode(Native Method)",
+    "androidx.security.crypto.EncryptedSharedPreferences.encryptKey(EncryptedSharedPreferences.java:614)",
+    "androidx.security.crypto.EncryptedSharedPreferences.encryptKeyValuePair(EncryptedSharedPreferences.java:647)",
+    "androidx.security.crypto.EncryptedSharedPreferences$Editor.putEncryptedObject(EncryptedSharedPreferences.java:391)",
+    "androidx.security.crypto.EncryptedSharedPreferences$Editor.putString(EncryptedSharedPreferences.java:258)",
+    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:32)",
+    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$9$lambda$8(MainActivity.kt:53)",
+    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$PhzGLzmkS_ibruOfiTT32AhzWl4(Unknown Source:0)"
+  ],
+  "inputParameters": [
+    {
+      "type": "[B",
+      "value": "0x0142f73f1e394b3336915ed6c4f013e82ffea42faa09d1673be72353fd82bf9bd565ae05..."
+    }
+  ],
+  "returnValue": [
+    {
+      "type": "java.lang.String",
+      "value": "AUL3Px45SzM2kV7WxPAT6C/+pC+qCdFnO+cjU/2Cv5vVZa4F"
+    }
+  ]
+}
+{
+  "id": "f331b615-6153-4fc1-a0d8-288793212497",
+  "category": "STORAGE",
+  "time": "2025-07-19T15:52:04.878Z",
+  "class": "javax.crypto.Cipher",
+  "method": "doFinal",
+  "stackTrace": [
+    "javax.crypto.Cipher.doFinal(Native Method)",
+    "com.google.crypto.tink.subtle.AesSiv.encryptDeterministically(AesSiv.java:124)",
+    "com.google.crypto.tink.daead.DeterministicAeadWrapper$WrappedDeterministicAead.encryptDeterministically(DeterministicAeadWrapper.java:78)",
+    "androidx.security.crypto.EncryptedSharedPreferences.encryptKey(EncryptedSharedPreferences.java:611)",
+    "androidx.security.crypto.EncryptedSharedPreferences.encryptKeyValuePair(EncryptedSharedPreferences.java:647)",
+    "androidx.security.crypto.EncryptedSharedPreferences$Editor.putEncryptedObject(EncryptedSharedPreferences.java:391)",
+    "androidx.security.crypto.EncryptedSharedPreferences$Editor.putString(EncryptedSharedPreferences.java:258)",
+    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:32)"
+  ],
+  "inputParameters": [
+    {
+      "type": "[B",
+      "value": "EncryptedAWSKey"
+    }
+  ],
+  "returnValue": [
+    {
+      "type": "[B",
+      "value": "0x09d1673be72353fd82bf9bd565ae05..."
+    }
+  ]
+}

--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/run.sh
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0060/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../../../../frida/android/run.sh ./hooks.js


### PR DESCRIPTION
Introduce a demonstration of securely storing sensitive data in an Android app using the EncryptedSharedPreferences class. The demo includes sample code, steps for execution, and validation of data encryption.