### PR TITLE
Fixed cross-ref to wrong tool.

### DIFF
--- a/techniques/ios/MASTG-TECH-0054.md
+++ b/techniques/ios/MASTG-TECH-0054.md
@@ -56,7 +56,7 @@ crypto   true
 
 In order to retrieve the unencrypted version, you can use [frida-ios-dump](https://github.com/AloneMonkey/frida-ios-dump "frida-ios-dump"). It will extract the unencrypted version from memory while the application is running on the device.
 
-First, configure @MASTG-TOOL-0054 `dump.py`:
+First, configure @MASTG-TOOL-0050 `dump.py`:
 
 - set it to use `localhost` with port `2222` when using @MASTG-TOOL-0055 (`iproxy 2222 22`), or to the actual IP address and port of the device from which you want to dump the binary.
 - update the default username (`User = 'root'`) and password (`Password = 'alpine'`) in `dump.py` to the ones you have set.


### PR DESCRIPTION
This PR closes (I didn't create an issue)

## Description

MASTG-TECH-0054 (Obtaining and Extracting Apps) mistakenly cross-references `ios-deploy` when it meant to reference `debug.py`. I updated the reference so that it points to the correct tool.

-------------------

[x] I have read the contributing guidelines.
