### PR TITLE
Port MASTG-TEST-0031: Testing JavaScript Execution in WebViews - Deprecate

### DIFF
--- a/tests/android/MASVS-PLATFORM/MASTG-TEST-0031.md
+++ b/tests/android/MASVS-PLATFORM/MASTG-TEST-0031.md
@@ -9,6 +9,9 @@ masvs_v1_levels:
 - L1
 - L2
 profiles: [L1, L2]
+status: deprecated
+covered_by: []
+deprecation_note: Having JavaScript enabled is not considered a vulnerability by itself, but it can lead to security issues in combination with other weaknesses, such as local file access in WebViews, which are covered by other tests in the MASTG v2. This test is therefore not considered a standalone test anymore.
 ---
 
 ## Overview


### PR DESCRIPTION
This PR closes #2982

## Description

Deprecate the JavaScript execution test and provide a note explaining its status and relevance in the context of security vulnerabilities.

-------------------

[x] I have read the contributing guidelines.

## Guidelines for Pull Requests (you can delete this section after reading):

- Please ensure that your content follows the [style guide](https://mas.owasp.org/contributing/).
- If you are working on Porting MASTG v1 Tests to v2, refer to [this document](https://docs.google.com/document/d/1veyzE4cVTSnIsKB1DOPUSMhjXow_MtJOtgHeo5HVoho/edit?usp=sharing).
- If you are working on new MASWE, tests, or demos, refer to [this document](https://docs.google.com/document/d/1EMsVdfrDBAu0gmjWAUEs60q-fWaOmDB5oecY9d9pOlg/edit?usp=sharing).

