### PR TITLE
Add Security Provider update best practice and corresponding test case

### DIFF
--- a/best-practices/MASTG-BEST-0014.md
+++ b/best-practices/MASTG-BEST-0014.md
@@ -1,0 +1,17 @@
+---
+title: Update the Security Provider
+alias: update-security-provider
+id: MASTG-BEST-0014
+platform: android
+---
+
+Android devices vary widely in OS version and update frequency. Relying solely on platform-level security can leave apps exposed to outdated SSL/TLS implementations and known vulnerabilities.
+
+**The GMS Security Provider** (delivered via Google Play Services) addresses this by updating critical cryptographic components—such as `OpenSSL` and `TrustManager`—**independently of the Android OS**. This helps ensure **secure network communication**, even on older or unpatched devices.
+
+It is strongly recommended to check and update the Security Provider **early during app startup**, ideally before making any secure network connections. Follow the Android Developer Documentation on [how to update the Security Provider to protect against SSL exploits](https://developer.android.com/privacy-and-security/security-gms-provider "Updating Your Security Provider to Protect Against SSL Exploits").
+
+If your app needs to support devices both **with and without Google Play Services** (such as Huawei devices, Amazon tablets, or AOSP-based ROMs), implement runtime checks to detect Play Services availability.
+
+- On GMS-enabled devices, use the Security Provider to keep cryptographic libraries up to date.
+- On non-GMS devices, consider bundling a secure TLS library like [Conscrypt](https://conscrypt.org) to ensure consistent and strong network security across your entire device fleet.

--- a/tests-beta/android/MASVS-NETWORK/MASTG-TEST-0295.md
+++ b/tests-beta/android/MASVS-NETWORK/MASTG-TEST-0295.md
@@ -1,0 +1,28 @@
+---
+title: Insecure or Missing Security Provider Update (Static)
+platform: android
+id: MASTG-TEST-0295
+type: [static]
+weakness: MASWE-0052
+profiles: [L2]
+best-practices: [MASTG-BEST-0014]
+---
+
+## Overview
+
+This test checks whether the Android app ensures the Security Provider (@MASTG-KNOW-0011) is [updated to mitigate SSL/TLS vulnerabilities](https://developer.android.com/privacy-and-security/security-gms-provider). The provider should be updated using Google Play Services APIs, and the implementation should handle exceptions securely.
+
+## Steps
+
+1. Reverse engineer the app (@MASTG-TECH-0017).
+2. Use static analysis (@MASTG-TECH-0014) to search for usage of `ProviderInstaller.installIfNeeded` or `ProviderInstaller.installIfNeededAsync`.
+
+## Observation
+
+The output should list all locations where the Security Provider update is performed and how exceptions are handled.
+
+## Evaluation
+
+The test fails if the app does not update the provider, or exception handling is missing/insecure. Check that these calls occur early in the app lifecycle (e.g., in `Application` or main `Activity`).
+
+The test passes if the app updates the Security Provider using the correct API and handles exceptions securely.

--- a/tests-beta/android/MASVS-NETWORK/MASTG-TEST-0295.md
+++ b/tests-beta/android/MASVS-NETWORK/MASTG-TEST-0295.md
@@ -1,5 +1,5 @@
 ---
-title: Insecure or Missing Security Provider Update (Static)
+title: GMS Security Provider Not Updated
 platform: android
 id: MASTG-TEST-0295
 type: [static]

--- a/tests/android/MASVS-NETWORK/MASTG-TEST-0023.md
+++ b/tests/android/MASVS-NETWORK/MASTG-TEST-0023.md
@@ -8,6 +8,9 @@ title: Testing the Security Provider
 masvs_v1_levels:
 - L2
 profiles: [L2]
+status: deprecated
+covered_by: [MASTG-TEST-0295]
+deprecation_note: New version available in MASTG V2
 ---
 
 ## Overview


### PR DESCRIPTION
Closes #2957

Introduce a best practice for updating the Security Provider to enhance SSL/TLS security on Android devices, along with a static test case to verify its implementation. The previous testing method is marked as deprecated in favor of the new approach.