### PR TITLE
Fix spell-checker.yml

### DIFF
--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -15,4 +15,3 @@ jobs:
         with:
           ignore_words_list: "aas,aaS,ba,bund,compliancy,firt,ist,keypair,ligh,Manuel,Manual,ro,ser,synopsys,theses,zuser,lief,EDE"
           skip: "*.json,*.yml,*.apk,*.ipa,*.svg,*.txt"
-          exclude_file: docs/contributing.md


### PR DESCRIPTION
This pull request makes a minor update to the spell checker workflow configuration by removing the exclusion of the `docs/contributing.md` file from spell checking.