### PR TITLE
Fix sources_override_json format in workflow

### DIFF
--- a/.github/workflows/check-website-build.yml
+++ b/.github/workflows/check-website-build.yml
@@ -9,4 +9,4 @@ jobs:
     uses: OWASP/mas-website/.github/workflows/build-website-reusable.yml@main
     with:
       deploy: false
-      sources_override_json: ${{ format('{{"OWASP/mastg":"{0}"}}', github.head_ref) }}
+      sources_override_json: ${{ format('{{"OWASP/mastg":"refs/heads/{0}"}}', github.head_ref) }}


### PR DESCRIPTION
This pull request updates the workflow configuration for building the website. The main change is to ensure that the branch reference for the `OWASP/mastg` source is fully qualified in the workflow input.

Workflow configuration update:

* The `sources_override_json` input in `.github/workflows/check-website-build.yml` is now set to use the full branch reference (`refs/heads/{0}`) for `OWASP/mastg`, improving compatibility and clarity when specifying the branch to use.