### PR TITLE
Update sources_override_json for pull request builds to consider forks

### DIFF
--- a/.github/workflows/check-website-build.yml
+++ b/.github/workflows/check-website-build.yml
@@ -9,4 +9,4 @@ jobs:
     uses: OWASP/mas-website/.github/workflows/build-website-reusable.yml@main
     with:
       deploy: false
-      sources_override_json: ${{ format('{{"OWASP/mastg":"refs/heads/{0}"}}', github.head_ref) }}
+      sources_override_json: ${{ format('{{"OWASP/mastg":"refs/pull/{0}/head"}}', github.event.pull_request.number) }}


### PR DESCRIPTION
This pull request updates the workflow configuration for building the website to ensure that pull request builds use the correct source reference. The main change is to how the `sources_override_json` is constructed, switching from using the branch name to using the pull request number.

Workflow configuration update:

* [`.github/workflows/check-website-build.yml`](diffhunk://#diff-6284d2d945d9134c3769fe6d8a0f2749b5568872171ba07696aecf158a1b0b5bL12-R12): Changed the `sources_override_json` input to reference the pull request number (`refs/pull/{number}/head`) instead of the branch name (`refs/heads/{branch}`), ensuring builds use the actual PR source.