### PR TITLE
Change class-dump source link to GitHub

### DIFF
--- a/tools/ios/MASTG-TOOL-0043.md
+++ b/tools/ios/MASTG-TOOL-0043.md
@@ -1,7 +1,7 @@
 ---
 title: class-dump
 platform: ios
-source: http://stevenygard.com/projects/class-dump/
+source: https://github.com/nygard/class-dump
 ---
 
-[class-dump by Steve Nygard](http://stevenygard.com/projects/class-dump/ "class-dump") is a command line utility for examining the Objective-C runtime information stored in Mach-O (Mach object) files. It generates declarations for the classes, categories, and protocols.
+[class-dump](http://stevenygard.com/projects/class-dump/) is a command line utility for examining the Objective-C runtime information stored in Mach-O (Mach object) files. It generates declarations for the classes, categories, and protocols.


### PR DESCRIPTION
Updated the source link for class-dump to the GitHub repository.

