### PR TITLE
Add placeholders for best practices, tests, and demos

### DIFF
--- a/best-practices/MASTG-BEST-0015.md
+++ b/best-practices/MASTG-BEST-0015.md
@@ -1,0 +1,8 @@
+---
+title: Use `setRecentsScreenshotEnabled` to Prevent Screenshots When Backgrounded
+alias: preventing-screenshots-when-backgrounded
+id: MASTG-BEST-0015
+platform: android
+status: placeholder
+note: Preventing screenshots when an app is backgrounded helps protect sensitive data from being exposed in system-generated snapshots used by the Recents screen.
+---

--- a/best-practices/MASTG-BEST-0016.md
+++ b/best-practices/MASTG-BEST-0016.md
@@ -1,0 +1,8 @@
+---
+title: Use `SECURE_FLAG` to Prevent Screenshots and Screen Recording
+alias: use-secure-flag-to-prevent-screenshots-and-screen-recording
+id: MASTG-BEST-0016
+platform: android
+status: placeholder
+note: Preventing screenshots and screen recording helps protect sensitive data from being exposed in system-generated snapshots and recordings.
+---

--- a/best-practices/MASTG-BEST-0017.md
+++ b/best-practices/MASTG-BEST-0017.md
@@ -1,0 +1,8 @@
+---
+title: Use `setSecure` to Prevent Screenshots in SurfaceViews
+alias: preventing-screenshots-and-screen-recording
+id: MASTG-BEST-0017
+platform: android
+status: placeholder
+note: Preventing screenshots and screen recording helps protect sensitive data from being exposed in system-generated snapshots and recordings.
+---

--- a/best-practices/MASTG-BEST-0018.md
+++ b/best-practices/MASTG-BEST-0018.md
@@ -1,0 +1,8 @@
+---
+title: Use `SecureFlagPolicy.SecureOn` to Prevent Screenshots in Compose Components
+alias: use-secureon-in-compose-components
+id: MASTG-BEST-0018
+platform: android
+status: placeholder
+note: Preventing screenshots and screen recording helps protect sensitive data from being exposed in system-generated snapshots and recordings.
+---

--- a/best-practices/MASTG-BEST-0019.md
+++ b/best-practices/MASTG-BEST-0019.md
@@ -1,0 +1,8 @@
+---
+title: Use Non-Caching Input Types for Sensitive Fields
+alias: use-non-caching-input-types
+id: MASTG-BEST-0019
+platform: android
+status: placeholder
+note: Using non-caching input types helps protect sensitive data from being exposed in system-generated snapshots and recordings.
+---

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0062/MASTG-DEMO-0062.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0062/MASTG-DEMO-0062.md
@@ -1,0 +1,9 @@
+---
+platform: android
+title: Enabling Screenshots in Recents via setRecentsScreenshotEnabled with semgrep
+id: MASTG-DEMO-0062
+code: [kotlin]
+test: MASTG-TEST-0292
+status: placeholder
+note: This demo shows how to detect the use of `setRecentsScreenshotEnabled(true)` in Android apps using Semgrep.
+---

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0063/MASTG-DEMO-0063.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0063/MASTG-DEMO-0063.md
@@ -1,0 +1,9 @@
+---
+platform: android
+title: Incorrectly Preventing Screenshots with SecureFlagPolicy in Compose Dialogs with semgrep
+id: MASTG-DEMO-0063
+code: [kotlin]
+test: MASTG-TEST-0293
+status: placeholder
+note: This demo shows how to detect the incorrect use of `SecureFlagPolicy` in Jetpack Compose dialogs using Semgrep.
+---

--- a/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0105.md
+++ b/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0105.md
@@ -1,0 +1,7 @@
+---
+title: User-Initiated Screenshots and Screen Recording
+platform: android
+masvs_category: MASVS-PLATFORM
+status: placeholder
+note: This topic explains how user-initiated screenshots and screen recordings work on Android.
+---

--- a/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0106.md
+++ b/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0106.md
@@ -1,0 +1,7 @@
+---
+title: App-Initiated Screenshots and Screen Recording
+platform: android
+masvs_category: MASVS-PLATFORM
+status: placeholder
+note: This topic explains how app-initiated screenshots and screen recordings work on Android.
+---

--- a/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0107.md
+++ b/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0107.md
@@ -1,0 +1,7 @@
+---
+title: Screenshots and Screen Recording Detection
+platform: android
+masvs_category: MASVS-PLATFORM
+status: placeholder
+note: This topic explains how screenshot and screen recording detection works on Android.
+---

--- a/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0292.md
+++ b/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0292.md
@@ -1,0 +1,11 @@
+---
+title: "`setRecentsScreenshotEnabled` Not Used to Prevent Screenshots When Backgrounded"
+platform: android
+id: MASTG-TEST-0292
+type: [static]
+profiles: [L2]
+best-practices: [MASTG-BEST-0014, MASTG-BEST-0015]
+weakness: MASWE-0055
+status: placeholder
+note: This test verifies whether an app prevents sensitive data from being captured in the Recents screen when backgrounded.
+---

--- a/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0293.md
+++ b/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0293.md
@@ -1,0 +1,11 @@
+---
+title: "`setSecure` Not Used to Prevent Screenshots in SurfaceViews"
+platform: android
+id: MASTG-TEST-0293
+type: [static]
+profiles: [L2]
+best-practices: [MASTG-BEST-0014, MASTG-BEST-0017]
+weakness: MASWE-0055
+status: placeholder
+note: This test verifies whether an app prevents sensitive data from being captured in screenshots and screen recordings of `SurfaceView` components.
+---

--- a/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0294.md
+++ b/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0294.md
@@ -1,0 +1,11 @@
+---
+title: "`SecureOn` Not Used to Prevent Screenshots in Compose Dialogs"
+platform: android
+id: MASTG-TEST-0294
+type: [static]
+profiles: [L2]
+best-practices: [MASTG-BEST-0014, MASTG-BEST-0018]
+weakness: MASWE-0055
+status: placeholder
+note: This test verifies whether an app prevents sensitive data from being captured in screenshots and screen recordings of Jetpack Compose dialogs.
+---


### PR DESCRIPTION
Introduce placeholders for various best practices, tests, and demo topics related to preventing screenshots and screen recordings in Android applications. These additions aim to enhance documentation and testing coverage for sensitive data protection.