### PR TITLE
Improve grammar and clarity in markdown instructions.

### DIFF
--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -13,18 +13,18 @@ The following markdown content rules are enforced in the validators:
 4. **Links**: Use standard Markdown link syntax.
 5. **Images**: Use HTML `<img>` tags for images. See the "Images" section for examples and guidelines.
 6. **Tables**: Use markdown tables for tabular data. Ensure proper formatting and alignment.
-8. **Whitespace**: Use appropriate whitespace to separate sections and improve readability.
-9. **Front Matter**: Include YAML front matter at the beginning of the file with required metadata fields.
+7. **Whitespace**: Use appropriate whitespace to separate sections and improve readability.
+8. **Front Matter**: Include YAML front matter at the beginning of the file with required metadata fields.
 
 ## Formatting and Structure
 
 Follow these guidelines for formatting and structuring your markdown content:
 
-- **Headings**: Use `##` for H2 and `###` for H3. Ensure that headings are used in a hierarchical manner. Recommend restructuring if content includes H4, and more strongly recommend for H5.
+- **Headings**: Use `##` for H2 and `###` for H3. Ensure that headings are used hierarchically. Recommend restructuring if the content includes H4, and more strongly recommend for H5.
 - **Lists**: Use `-` for bullet points and `1.` for numbered lists. Indent nested lists with four spaces to match the linter configuration. Prefer dashes `-` over asterisks `*` for unordered lists. Generally:
   - Limit a single list to at most nine items when reasonable.
   - Avoid more than two levels of nesting.
-  - Punctuate and capitalize list items consistently. Do not add end punctuation to list items that are not complete sentences unless they complete the introductory sentence. If list items complete an introductory sentence, end each (except the last) with a comma, omit the "and" before the last, and end the last with appropriate punctuation.
+  - Punctuate and capitalize list items consistently. Do not add end punctuation to list items that are not complete sentences unless they complete the introductory sentence. If list items complete an introductory sentence, end each (except the last) with a comma, omit the "and" before the last, and end the last item with appropriate punctuation.
 - **Code Blocks**: Use triple backticks to create fenced code blocks. Specify the language after the opening backticks for syntax highlighting (e.g., kt, java, xml).
 - **Links**: Ensure the link text is descriptive and the URL is valid.
 - **Tables**: Use `|` to create tables. Ensure that columns are properly aligned and headers are included.
@@ -42,7 +42,7 @@ Follow these guidelines for formatting and structuring your markdown content:
 
 ### Content Length and Organization
 
-- Use short, scannable pages where possible (roughly one to two screens of text). For very large sections, consider moving details to a supporting document and link to it.
+- Use short, scannable pages where possible (roughly one to two screens of text). For extensive sections, consider moving details to a supporting document and linking to it for clarity and conciseness.
 - For digital content, favor shorter, cross-linked pages. If the content is intended for print, longer, comprehensive pages are acceptable.
 
 ### Gender Neutrality
@@ -66,7 +66,7 @@ Follow these guidelines for formatting and structuring your markdown content:
 
 ### Abbreviations
 
-- On first use, spell out the term followed by the abbreviation in parentheses; use the abbreviation alone on subsequent uses within the chapter.
+- On first use, spell out the term followed by the abbreviation in parentheses; use the acronym alone on subsequent uses within the chapter.
 - If the term appears only once, prefer the full term instead of the abbreviation.
 - In titles/headings, abbreviations are acceptable, but introduce them properly in the following text.
 - Use "a" or "an" based on pronunciation (e.g., a URL, an APK).
@@ -106,7 +106,7 @@ best-practices: [MASTG-BEST-0010, MASTG-BEST-0011, MASTG-BEST-0012]
 - Never use Horizontal rules like `---`.
 - Emphasis/strong style: underscores for emphasis (`_text_`), asterisks for strong (`**text**`).
 - Trailing punctuation allowed in headings (MD026) is limited to: `.,;:`
-- Always prefer commas or parentheses over em-dashes, en-dashes or hyphens.
+- Always prefer commas or parentheses over em-dashes, en-dashes, or hyphens.
 
 ## Images
 
@@ -123,12 +123,12 @@ Example:
 <img src="Images/Chapters/0x05b/r2_pd_10.png" width="80%" />
 ```
 
-Note: The linter does not require alt text for images (MD045 disabled); however, include descriptive context in the surrounding text when helpful for accessibility.
+Note: The linter does not require alt text for images (MD045 is disabled); however, including descriptive context in the surrounding text is helpful for accessibility.
 
 ## Validation Requirements
 
 Ensure compliance with the following validation requirements:
 
 - **Content Rules**: Ensure that the content follows the markdown content rules specified above.
-- **Formatting**: Ensure that the content is properly formatted and structured according to the guidelines.
+- **Formatting**: Ensure that the content is appropriately formatted and structured according to the guidelines.
 - **Validation**: Run the validation tools to check for compliance with the rules and guidelines.

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -66,7 +66,7 @@ Follow these guidelines for formatting and structuring your markdown content:
 
 ### Abbreviations
 
-- On first use, spell out the term followed by the abbreviation in parentheses; use the acronym alone on subsequent uses within the chapter.
+- On first use, spell out the term followed by the abbreviation in parentheses; use the abbreviation alone on subsequent uses within the chapter.
 - If the term appears only once, prefer the full term instead of the abbreviation.
 - In titles/headings, abbreviations are acceptable, but introduce them properly in the following text.
 - Use "a" or "an" based on pronunciation (e.g., a URL, an APK).

--- a/.github/instructions/mastg-apps.instructions.md
+++ b/.github/instructions/mastg-apps.instructions.md
@@ -12,7 +12,7 @@ Standards for authoring reference application pages under `apps/`. These pages d
 
 - The filename defines the app ID: `MASTG-APP-\d{4}.md`
 - Do not add an `id:` field to the YAML front matter
-- Use the following available number within the platform folder. Coordinate in PRs to avoid collisions
+- Use the next available number in the platform folder. Coordinate in PRs to avoid collisions
 
 ## Markdown structure
 

--- a/.github/instructions/mastg-apps.instructions.md
+++ b/.github/instructions/mastg-apps.instructions.md
@@ -1,6 +1,6 @@
 # Reference Apps Authoring Instructions
 
-Standards for authoring reference application pages under `apps/`. These pages describe vulnerable or exemplar applications used across tests, techniques, and demos.
+Standards for authoring reference application pages under `apps/`. These pages describe vulnerable or exemplary applications used across tests, techniques, and demos.
 
 ## Locations
 
@@ -10,9 +10,9 @@ Standards for authoring reference application pages under `apps/`. These pages d
 
 ## File naming and IDs
 
-- The app ID is defined by the filename: `MASTG-APP-\d{4}.md`
+- The filename defines the app ID: `MASTG-APP-\d{4}.md`
 - Do not add an `id:` field to the YAML front matter
-- Use the next available number within the platform folder. Coordinate in PRs to avoid collisions
+- Use the following available number within the platform folder. Coordinate in PRs to avoid collisions
 
 ## Markdown structure
 
@@ -52,11 +52,11 @@ package: sg.vantagepoint.uncrackable1
 Entries should be short and referential. Do not duplicate installation or usage docs that belong in the app’s own repository.
 
 - One or two sentences describing the app and its purpose
-- Add any platform-specific hints such as jailbreak expectations or proxy setup
+- Add any platform-specific hints, such as jailbreak expectations or proxy setup
 
 ### Cross-linking
 
-In YAML front matter add `weaknesses` listing all the weaknesses from the MASWE that can be tested and are present in the app.
+In the YAML front matter, add `weaknesses` listing all the weaknesses from the MASWE that can be tested and are present in the app.
 
 Example:
 
@@ -64,7 +64,7 @@ Example:
 weaknesses: [MASWE-0034, MASWE-0056]
 ```
 
-Do not add specific app versions here. If a MASTG-DEMO requires a specific version of an app, document it in the demo, not in the app entry.
+Do not add specific app versions here. If a MASTG-DEMO requires a particular version of an app, document it in the demo, not in the app entry.
 
 ## Writing conventions
 

--- a/.github/instructions/mastg-best-practice.instructions.md
+++ b/.github/instructions/mastg-best-practice.instructions.md
@@ -49,7 +49,7 @@ Best Practices should contain:
 
 - what's the recommendation
 - why is that good
-- any caveats or considerations (for example, "it's good to have it but remember it can be bypassed this way")
+- any caveats or considerations (for example, "it's good to have it, but remember it can be bypassed this way")
 - official references
 
 ### Recommended Structure
@@ -73,7 +73,7 @@ Example References section:
 
 ### Cross-linking
 
-- From tests: use `best-practices: [MASTG-BEST-0001, MASTG-BEST-0011]` in the test’s YAML front matter. The site generator will create Mitigations links automatically.
+- From tests: use `best-practices: [MASTG-BEST-0001, MASTG-BEST-0011]` in the test’s YAML front matter. The site generator will automatically create Mitigations links.
 - In body text: reference tests, tools, or techniques with @ (for example, @MASTG-TEST-0252, @MASTG-TOOL-0031).
 
 ### Style

--- a/.github/instructions/mastg-demo.instructions.md
+++ b/.github/instructions/mastg-demo.instructions.md
@@ -13,16 +13,16 @@ Demos live in `demos/android/` or `demos/ios/` under the corresponding MASVS cat
 
 **Decompiled Code:** Decompiled code must be provided if the demo involves static analysis.
 
-- **Android:** Follow the instructions in ["MASTestApp for Android - Run the Extraction Script"](https://github.com/cpholguera/mas-app-android) to obtain the relevant files such as the reversed `AndroidManifest.xml` and the `MastgTest_reversed.java` which is the MASTestApp's main file. Including the full version of these files is also useful for understanding the code in the context of the application, regardless of whether the demo focuses on a specific snippet.
-- **iOS:** Follow the instructions in ["MASTestApp for iOS - Reverse Engineering"](https://github.com/cpholguera/MASTestApp-iOS) to obtain the relevant files such as the the IPA file and the reversed `Info.plist` already converted to XML format. Currently you need to manually extract the main binary, MASTestApp, and include it in the demo folder (we allow this for now since the files are sufficiently small). The demos will typically use reverse engineering tools like `r2` on this binary.
+- **Android:** Follow the instructions in ["MASTestApp for Android - Run the Extraction Script"](https://github.com/cpholguera/mas-app-android) to obtain the relevant files, such as the reversed `AndroidManifest.xml` and the `MastgTest_reversed.java`, which is the MASTestApp's main file. Including the full version of these files is also useful for understanding the code in the context of the application, regardless of whether the demo focuses on a specific snippet.
+- **iOS:** Follow the instructions in ["MASTestApp for iOS - Reverse Engineering"](https://github.com/cpholguera/MASTestApp-iOS) to obtain the relevant files, such as the IPA file and the reversed `Info.plist` already converted to XML format. Currently, you need to extract the main binary, MASTestApp, manually, and include it in the demo folder (we allow this for now since the files are sufficiently small). The demos will typically use reverse engineering tools, such as `r2`, on this binary.
 
 The **demos MUST WORK**. See [Code Samples](#code-samples).
 
 Demos are required to be **fully self-contained** and should **not rely on external resources or dependencies**. This ensures that the demos can be run independently and that the results are reproducible. They must be proven to work on the provided sample applications and must be tested thoroughly before being included in the MASTG.
 
-**Don't create demos for outdated OS versions** that aren't supported by the MASTG. The MASTestApp is meant to always be up to date and aligned with the versions supported by the MASTG, so as to avoid additional maintenance of the MASTestApp. However, you can include demos showcasing the "good case" in the metadata using `kind: pass` in certain cases where it can be helpful or educational. This is permitted as long as the demos work with the current version of the MASTestApp.
+**Don't create demos for outdated OS versions** that aren't supported by the MASTG. The MASTestApp is always intended to be up to date and aligned with the versions supported by the MASTG, thereby avoiding additional maintenance of the MASTestApp. However, you can include demos showcasing the "good case" in the metadata using `kind: pass` in certain cases where it can be helpful or educational. This is permitted as long as the demos work with the current version of the MASTestApp.
 
-Please specify the mobile platform version, IDE and version, device.
+Please specify the mobile platform version, IDE version, and device.
 
 Android Example:
 
@@ -72,13 +72,13 @@ title: Common Uses of Insecure Random APIs
 
 #### platform
 
-The mobile platform. One of: ios, android.
+The mobile platform. One of: `ios`, `android`.
 
 #### tools
 
 Tools used in the demo.
 
-Prefer referencing official tool IDs from https://mas.owasp.org/MASTG/tools/ when available (for example, `MASTG-TOOL-0031`). If an official ID is not available, you may use a well-known tool name (for example, `semgrep`).
+When available, prefer referencing official tool IDs from https://mas.owasp.org/MASTG/tools/ (for example, `MASTG-TOOL-0031`). If an official ID is not available, you may use a well-known tool name (for example, `semgrep`).
 
 Example:
 
@@ -131,7 +131,7 @@ Include these if relevant:
 
 #### Sample
 
-Shortly describe the sample and specify the exact sample files used using this notation:
+Shortly describe the sample and specify the exact sample files using this notation:
 
 **Single file:**
 
@@ -150,14 +150,14 @@ Example:
 ```md
 ### Sample
 
-The snippet below shows sample code that sends sensitive data over the network using the `HttpURLConnection` class. The data is sent to `https://httpbin.org/post` which is a dummy endpoint that returns the data it receives.
+The snippet below shows sample code that sends sensitive data over the network using the `HttpURLConnection` class. The data is sent to `https://httpbin.org/post`, which is a dummy endpoint that returns the data it receives.
 
 {{ MastgTest.kt # MastgTest_reversed.java }}
 ```
 
 #### Steps
 
-A concise writeup following all steps from the linked test, including placeholders for testing code and scripts (for example, SAST rules, `run.sh`).
+A concise write-up following all steps from the linked test, including placeholders for testing code and scripts (for example, SAST rules, `run.sh`).
 
 Example:
 
@@ -173,7 +173,7 @@ Let's run our semgrep rule against the sample code.
 
 #### Observation
 
-A concise description of the observation for this specific demo including placeholders for output files (for example, `output.txt`, `output.json`).
+A concise description of the observation for this specific demo, including placeholders for output files (for example, `output.txt`, `output.json`).
 
 Example:
 
@@ -198,9 +198,9 @@ Review each of the reported instances.
 
 - Line 12 seems to be used to generate random numbers for security purposes, in this case for generating authentication tokens.
 - Line 17 is part of the function `get_random`. Review any calls to this function to ensure that the random number is not used in a security-relevant context.
-- Line 27 is part of the password generation function which is a security-critical operation.
+- Line 27 is part of the password generation function, which is a security-critical operation.
 
-Note that line 37 did not trigger the rule because the random number is generated using `SecureRandom` which is a secure random number generator.
+Note that line 37 did not trigger the rule because the random number is generated using `SecureRandom`, which is a secure random number generator.
 ```
 
 
@@ -220,7 +220,7 @@ Must be a modified version of the original files in the apps’ repos:
 * Android: `app/src/main/java/org/owasp/mastestapp/MastgTest.kt`
 * iOS: `MASTestApp/MastgTest.swift`
 
-When working on a new demo you **must include the whole file** with the original name in the demo folder.
+When working on a new demo, you **must include the whole file** with the original name in the demo folder.
 
 #### Summary
 
@@ -229,26 +229,26 @@ Must contain a summary as a comment.
 Example:
 
 ```kt
-// SUMMARY: This sample demonstrates different common ways of insecurely generating random numbers in Java.
+// SUMMARY: This sample demonstrates various common ways of generating random numbers insecurely in Java.
 ```
 
 #### Logic
 
 The file must include code that demonstrates the addressed weakness.
-The provided default `MastgTest.kt` and `MastgTest.swift` contain some basic logic that will return a string to the UI. If possible try to return some meaningful string.
+The provided default `MastgTest.kt` and `MastgTest.swift` files contain some basic logic that returns a string to the UI. If possible, try to return some meaningful string.
 
-For example, if you create a random number you can return it; or if you write files to the external storage you can return a list of file paths so that the user of the app can read them. You can also use that string to display some meaningful errors.
+For example, if you generate a random number, you can return it; or if you write files to external storage, you can return a list of file paths so that the app's user can read them. You can also use that string to display some meaningful errors.
 
 #### Fail/Pass
 
-Must contain comments indicating fail/pass and the test alias. This way we're able to validate that the output is correct (e.g. the code contains 3 failures of `MASTG-TEST-0204`). We can easily parse and count the comments and we can do the same in the output.
+Must contain comments indicating fail/pass and the test alias. This way, we can validate that the output is correct (e.g., the code contains three failures of `MASTG-TEST-0204`). We can easily parse and count the comments, and we can do the same in the output.
 
-Each FAIL/PASS comment must include the test Id and an explanation of why it fails/passes.
+Each FAIL/PASS comment must include the test ID and an explanation of why it fails/passes.
 
 Example:
 
 ```kt
-// FAIL: [MASTG-TEST-0204] The app insecurely uses random numbers for generating authentication tokens.
+// FAIL: [MASTG-TEST-0204] The app insecurely generates authentication tokens using random numbers.
 return r.nextDouble();
 
 

--- a/.github/instructions/mastg-frida-scripts.instructions.md
+++ b/.github/instructions/mastg-frida-scripts.instructions.md
@@ -33,8 +33,8 @@ Examples:
 
 ### Inspiration
 
-- Don't reinvent the wheel when something already exists. Use existing open-source sources when available, for example https://codeshare.frida.re/browse.
-- If you use a source be sure to document it and give creadit to the author. Include a link to the original source in a comment at the beginning of the frida script.
+- Don't reinvent the wheel when something already exists. Use existing open-source sources when available, for example, https://codeshare.frida.re/browse.
+- If you use a source, be sure to document it and give credit to the author. Include a link to the source in a comment at the beginning of the frida script.
 
 Example:
 

--- a/.github/instructions/mastg-knowledge.instructions.md
+++ b/.github/instructions/mastg-knowledge.instructions.md
@@ -12,7 +12,7 @@ Locations and taxonomy:
 
 File naming and IDs:
 
-- The knowledge ID is defined by the filename: `MASTG-KNOW-\d{4}.md`.
+- The filename defines the knowledge ID: `MASTG-KNOW-\d{4}.md`.
 - Do not add an `id:` field to the YAML front matter.
 - Place the file in the platform (`android` or `ios`) and MASVS category folder that best matches the subject.
 
@@ -48,13 +48,13 @@ available_since: 18
 
 ### Markdown: Body
 
-Keep content authoritative, concise, and platform-focused. Avoid duplicating OS documentation; cite it and summarize what the feature is and how it works.
+Keep content authoritative, concise, and platform-focused. Avoid duplicating OS documentation. Instead, cite it and summarize the feature, including its purpose and functionality.
 
 Considerations for writing the content:
 
 - Define the concept and its scope. Relate to OS components, APIs, or security model elements.
 - Explain typical security-relevant behaviors or implications of the feature without necessarily recommending mitigations (that's for "best practices").
-- Include specific API names, version nuances, storage locations, configuration knobs. Try to avoid code samples; instead try to refer to existing MASTG-DEMO code files. If you include them keep them short and explanatory.
+- Include specific API names, version nuances, storage locations, and configuration knobs. Try to avoid code samples. Instead, refer to the existing MASTG-DEMO code files. If you include them, keep them short and explanatory.
 - Use references from official docs and standards. Avoid non-authoritative sources.
 - In body text, reference internal MAS identifiers with a leading `@` (for example, @MASTG-KNOW-0001, @MASTG-TEST-0204, @MASTG-TECH-0014, @MASTG-TOOL-0031, MASWE-0089).
 
@@ -70,11 +70,11 @@ Considerations for writing the content:
 - Cross-category content: If a topic spans two MASVS categories, choose the best fit and reference the other in the body; avoid duplicate pages.
 - Generic vs platform: Concepts that are identical across platforms should be split into platform folders if platform detail matters; otherwise, place details where they differ and keep overviews succinct.
 - Where to place recommendations: Keep all prescriptive advice (do/don't, secure configuration values, mitigations) in Best Practices pages under `best-practices/`, and link them from the "Related" section.
-- When writing tests, techniques, tools always try to link to a knowledge article or create one if it's missing.
+- When writing tests, techniques, or tools, always try to link to a knowledge article or create one if it's missing.
 
 ## Deprecation
 
-If the original source is gone, not relevant anymore, or too old, set the following in the YAML front matter:
+If the source is gone, not relevant anymore, or too old, set the following in the YAML front matter:
 
 - `status:` Must be set to `deprecated`
 - `deprecation_note:` Short clarifying note for deprecation. Keep phrasing concise and imperative

--- a/.github/instructions/mastg-mitmproxy-scripts.instructions.md
+++ b/.github/instructions/mastg-mitmproxy-scripts.instructions.md
@@ -20,7 +20,7 @@ This guide defines how to write and use mitmproxy scripts in MASTG demos. Script
 - Keep `run.sh` responsible for:
   - Starting/stopping mitmdump (foreground or background as appropriate to the demo flow).
   - Managing output files produced by the script (for example, `sensitive_data.log`).
-  - Ensuring the device/emulator routes traffic through the proxy (defer details to Tools page).
+  - Ensuring the device/emulator routes traffic through the proxy (defer details to the Tools page).
 
 ### Coding conventions
 
@@ -84,7 +84,7 @@ def response(flow: http.HTTPFlow):
 ### Logging and outputs
 
 - Default to writing a deterministic, append-only file (for example, `sensitive_data.log`) in the demo folder. Reference it in the Observation and Evaluation sections.
-- Keep the format simple and consistent—avoid timestamps unless needed for the demo, to keep diffs small.
+- Keep the format consistent and straightforward. Avoid timestamps unless needed for the demo to keep diffs small.
 - If multiple outputs are produced, document them in the demo’s Steps.
 
 ### Alignment with Tools

--- a/.github/instructions/mastg-r2-scripts.instructions.md
+++ b/.github/instructions/mastg-r2-scripts.instructions.md
@@ -1,6 +1,6 @@
 ## r2 scripts (radare2)
 
-This guide defines how to write and use radare2 scripts in MASTG demos. Scripts live with the demo and are executed by `run.sh` to produce Observation output.
+This guide defines how to write and use radare2 scripts in MASTG demos. Scripts are included with the demo and executed by `run.sh` to produce the Observation output.
 
 ### Scope and terminology
 

--- a/.github/instructions/mastg-rules.instructions.md
+++ b/.github/instructions/mastg-rules.instructions.md
@@ -28,7 +28,7 @@ Required fields per rule:
 - **languages**: usually `xml` or `java` (we don’t create rules for Kotlin as we work with decompiled Java; use `xml` for AndroidManifest and resource rules).
 - **metadata**: must include summary
     - summary: Short description of the rule.
-    - original_source: you may use rules from sources on the internet be sure to check that the license allows this and always link to the original source here. Modify the rule if needed and the license allows for it.
+    - original_source: You may use rules from sources on the internet. Be sure to check that the license allows this, and always link to the source here. Modify the rule as needed, provided the license permits it.
 - **message**: must start with a MASVS identifier and concisely explain what the rule is reporting. Prefer a specific control when applicable (for example, `[MASVS-PLATFORM-2]`); otherwise, use the MASVS category tag (for example, `[MASVS-STORAGE]`).
 - **patterns**: see [https://semgrep.dev/docs/writing-rules/pattern-syntax/](https://semgrep.dev/docs/writing-rules/pattern-syntax/)
 
@@ -39,7 +39,7 @@ Multiple rules per file
 
 General guidance
 
-- Do not include authors in the semgrep rules. If it was copied from some other place, **include the link to the original source**. Since many people will contribute, authorship is tracked via git history.
+- Do not include authors in the semgrep rules. If it was copied from another source, **include the link to the source**. Since many people will contribute, authorship is tracked via git history.
 - Keep messages concise and actionable; they should be understandable without reading the pattern body.
 - Test rules in the Semgrep Playground and against reversed code from the demos.
 
@@ -52,7 +52,7 @@ rules:
     languages:
       - java
     metadata:
-      summary: This rule looks for common patterns including classes and methods.
+      summary: This rule looks for common patterns, including classes and methods.
     message: "[MASVS-CRYPTO-1] The application makes use of an insecure random number generator."
 
     pattern-either:

--- a/.github/instructions/mastg-techniques.instructions.md
+++ b/.github/instructions/mastg-techniques.instructions.md
@@ -13,7 +13,7 @@ File naming and IDs:
 
 - The filename defines the technique ID: `MASTG-TECH-\d{4}.md`.
 - Do not add an `id:` field to the YAML front matter for techniques.
-- Use the next available increment number within the platform folder. Coordinate in PRs to avoid collisions.
+- Use the next available number within the platform folder. Coordinate in PRs to avoid collisions.
 
 Follow the global Markdown rules (see `.github/instructions/markdown.instructions.md`). Use `##` for top-level sections inside the page.
 

--- a/.github/instructions/mastg-techniques.instructions.md
+++ b/.github/instructions/mastg-techniques.instructions.md
@@ -11,9 +11,9 @@ Locations:
 
 File naming and IDs:
 
-- The technique ID is defined by the filename: `MASTG-TECH-\d{4}.md`.
+- The filename defines the technique ID: `MASTG-TECH-\d{4}.md`.
 - Do not add an `id:` field to the YAML front matter for techniques.
-- Use the next available number within the platform folder. Coordinate in PRs to avoid collisions.
+- Use the next available increment number within the platform folder. Coordinate in PRs to avoid collisions.
 
 Follow the global Markdown rules (see `.github/instructions/markdown.instructions.md`). Use `##` for top-level sections inside the page.
 
@@ -110,4 +110,4 @@ You should see method entries in the console matching the targeted patterns. If 
 
 - Multi-platform techniques: If steps are identical across platforms, place the page under `generic/`. If they differ meaningfully, create separate platform pages.
 - Tool selection: Link to multiple tools when appropriate and list trade-offs briefly in the text; keep detailed tool usage on the tool pages.
-- Deprecation: If a technique becomes obsolete (for example, platform removed capability), set `status: deprecated` and add a short note at the top explaining why, with links to alternatives.
+- Deprecation: If a technique becomes obsolete (for example, a platform's removed capability), set `status: deprecated` and add a short note at the top explaining why, with links to alternatives.

--- a/.github/instructions/mastg-test.instructions.md
+++ b/.github/instructions/mastg-test.instructions.md
@@ -57,7 +57,7 @@ The test ID.
 
 #### weakness
 
-The MASWE weakness ID that the test references.
+The MASWE weakness ID associated with this test.
 
 - In YAML front matter, specify the bare identifier (for example, `weakness: MASWE-0069`). In body text, include the leading `@` (for example, @MASWE-0069).
 

--- a/.github/instructions/mastg-test.instructions.md
+++ b/.github/instructions/mastg-test.instructions.md
@@ -32,7 +32,7 @@ Each test has two parts: the [Markdown metadata](#markdown-metadata) (YAML `fron
 
 Test titles should be concise and clearly state the purpose of the test.
 
-In some cases, the test name and the weakness may have the same title, but typically tests cover different aspects of a weakness. Titles should reflect that.
+In some cases, the test name and the weakness may have the same title, but typically, tests cover different aspects of a weakness. Titles should reflect that.
 
 Avoid including Android or iOS unless necessary, as in "Insecure use of the Android Protected Confirmation API".
 
@@ -43,11 +43,11 @@ Follow a consistent style across all test titles.
 - Static: “References to…” (semgrep/r2)
 - Dynamic: “Runtime Use …” (frida)
 
-Exceptions may apply where "Runtime ..." feels forced, for example tests using adb, local backups, or filesystem snapshots.
+Exceptions may apply where "Runtime ..." feels forced, for example, tests using adb, local backups, or filesystem snapshots.
 
 #### platform
 
-The mobile platform. One of: ios, android, network.
+The mobile platform. One of the following: iOS, Android, or network.
 
 - Use network for platform-agnostic traffic analysis tests where the checks are performed purely on captured/observed traffic (often paired with type: [network]).
 
@@ -57,7 +57,7 @@ The test ID.
 
 #### weakness
 
-The MASWE weakness ID the test references.
+The MASWE weakness ID that the test references.
 
 - In YAML front matter, specify the bare identifier (for example, `weakness: MASWE-0069`). In body text, include the leading `@` (for example, @MASWE-0069).
 
@@ -70,7 +70,7 @@ Supported:
 - `static`: analysis of the app binary, reverse-engineered source code, or developer artifacts that are available in the APK/IPA app package (e.g., Android manifest, Info.plist, entitlements, etc.). No execution of the app is required.
 - `dynamic`: analysis of the app while it is running and involves runtime analysis such as hooking or method tracing.
 - `manual`: manual steps that require human judgment, such as inspecting app behavior, UI, or configuration. This may include reverse engineering or runtime analysis that cannot be fully automated.
-- `network`: analysis of network traffic, while the app is running. Done externally, for example using a proxy or network capture tool.
+- `network`: analysis of network traffic, while the app is running. Done externally, for example, using a proxy or network capture tool.
 - `filesystem`: analysis of the app's file system, including local storage or backups, which doesn't involve runtime analysis such as hooking or method tracing.
 - `developer`: tests only the developer can perform because they require access to the source code, build process, or other internal resources.
 
@@ -106,7 +106,7 @@ Notes:
 
 #### prerequisites
 
-List prerequisites needed to execute or evaluate the test. Existing files are in `prerequisites/`. Create new ones if needed.
+List the prerequisites needed to execute or evaluate the test. Existing files are in `prerequisites/`. Create new ones if required.
 
 - If there are no prerequisites, you can omit this field or use an empty list.
 
@@ -120,7 +120,7 @@ prerequisites:
 
 #### profiles
 
-Specify MASVS profiles where the test applies. Valid values: L1, L2, P, R.
+Specify the MASVS profiles to which the test applies. Valid values: L1, L2, P, R.
 The profiles are described in [MAS Testing Profiles Guide]( https://docs.google.com/document/d/1paz7dxKXHzAC9MN7Mnln1JiZwBNyg7Gs364AJ6KudEs/edit?tab=t.0#heading=h.il6q80u4fm3n)
 
 - L1 denotes Essential Security.
@@ -164,7 +164,7 @@ Android apps sometimes use insecure pseudorandom number generators (PRNGs) such 
 
 #### Steps
 
-A test must include one or more steps. Steps can be static, dynamic, manual, or mixed.
+A test must include at least one step. Steps can be static, dynamic, manual, or a combination of these.
 
 Example, to check app notifications:
 
@@ -185,7 +185,7 @@ Example:
 Notes:
 
 - Always link to existing MASTG-TECH by ID (for example, @MASTG-TECH-0014)
-- Don't reference MASTG tools directly (this may still be happening in some tests and we must fix it.)
+- Don't reference MASTG tools directly (this may still be happening in some tests, and we must fix it.)
 - Be consistent by reusing the steps from existing tests. Do not create new phrasing or wording when it's not necessary.
 
 #### Observation

--- a/.github/instructions/mastg-tools.instructions.md
+++ b/.github/instructions/mastg-tools.instructions.md
@@ -68,13 +68,13 @@ Keep pages practical, scannable, and focused on security testing use.
 ### Cross-linking
 
 - Do not cross-link here to tests, demos, and techniques, etc.
-- Those components will cross-link to tools, typically techniques and demos
-- To do that they must add @MASTG-TOOL-0031 in their markdown body or as `tools: [MASTG-TOOL-0031]` in their YAML front matter
+- Those components will cross-link to tools, typically techniques, and demos
+- To do that, they must add @MASTG-TOOL-0031 in their markdown body or as `tools: [MASTG-TOOL-0031]` in their YAML front matter
 
 ## Conventions and quality
 
 - Prefer official sources for installation steps. Avoid advertising or endorsing third-party distributions
-- Favor commands that work across supported hosts when possible. Otherwise clearly label host-specific commands
+- Favor commands that work across supported hosts when possible. Otherwise, clearly label host-specific commands
 - For images, use HTML `<img>` tags per the markdown instructions (store assets in an appropriate images folder if needed)
 - Keep examples minimal and verifiable. Longer walkthroughs belong in demos with runnable scripts
 

--- a/.github/instructions/porting-mastg-v1-tests-to-v2.instructions.md
+++ b/.github/instructions/porting-mastg-v1-tests-to-v2.instructions.md
@@ -4,14 +4,14 @@
 
 This document focuses on the porting workflow. For how to write v2 tests (front matter fields, required sections, styles), see `mastg-test.instructions.md`. Do not duplicate that guidance here—follow it when drafting the ported test.
 
-Check some of the current tests and take them as reference
+Check some of the current tests and take them as a reference.
 
 * tests-beta
 * demos
 
-Always take the most recent tests (the ones with the highest IDs) as reference/template. Use `tests-beta` files as the canonical template for structure and front matter.
+Always use the most recent tests (those with the highest IDs) as a reference/template. Use `tests-beta` files as the canonical template for structure and front matter.
 
-Also review these. We’ll be using them and creating new ones as well:
+Also, review these. We’ll be using them and creating new ones as well:
 
 * [https://mas.owasp.org/MASTG/techniques/](https://mas.owasp.org/MASTG/techniques/)
 * [https://mas.owasp.org/MASTG/tools/](https://mas.owasp.org/MASTG/tools/) 
@@ -24,7 +24,7 @@ Also review these. We’ll be using them and creating new ones as well:
 **Important** tips and guidelines: 
 
 1. Create a rough draft.
-   1. In most cases you’ll have something in the v1 test
+   1. In most cases, you’ll have something in the v1 test
    2. Sometimes you can take the whole test or just a sentence or bullet point.
    3. You may use [chatGPT](https://chat.openai.com/) to create an initial draft and massage the content.
 2. Edit it yourself using **your knowledge**
@@ -49,7 +49,7 @@ Also review these. We’ll be using them and creating new ones as well:
 
 #### List of sources
 
-Use the MASTG first, e.g. the guides for 0x04 (general), 0x05 (Android) and 0x06 (iOS) and **extend** with android/apple docs.
+Use the MASTG first: e.g., the guides for 0x04 (general), 0x05 (Android), and 0x06 (iOS), and **extend** with Android/Apple docs.
 
 **Android** 
 
@@ -65,50 +65,50 @@ Use the MASTG first, e.g. the guides for 0x04 (general), 0x05 (Android) and 0x06
 
 ## Porting workflow
 
-Map to MASWE. You can check the new MASWE by searching for the old test ID in the **weaknesses/** directory. For example MASTG-TEST-0017.
+Map to MASWE. You can check the new MASWE by searching for the old test ID in the **weaknesses/** directory, for example, MASTG-TEST-0017.
 
-1) Create a branch for the ticket: `port-MASTG-TEST-0017` (adjust ID).
+1. Create a branch for the ticket: `port-MASTG-TEST-0017` (adjust ID).
 
-2) Place files correctly: If the relevant `MASVS-*` folder does not exist yet under `tests-beta/<platform>/`, create it.
+2. Place files correctly: If the relevant `MASVS-*` folder does not exist yet under `tests-beta/<platform>/`, create it.
 
-3) Name the new file using the decimal ID (for example, `MASTG-TEST-0233.md`).
+3. Name the new file using the decimal ID (for example, `MASTG-TEST-0233.md`).
 
-4) Decide scope changes: One v1 test may become one or multiple v2 tests (or be merged). Capture only what is testable and actionable; move general theory elsewhere (see below).
+4. Decide scope changes: One v1 test may become one or multiple v2 tests (or be merged). Capture only what is testable and actionable; move general theory elsewhere (see below).
 
-5) Gather references: Search for references in `Document/`, `techniques/`, `tools/`, and `knowledge/`.
+5. Gather references: Search for references in `Document/`, `techniques/`, `tools/`, and `knowledge/`.
 
-6) Normalize background vs test logic: Add platform background as @MASTG-KNOW-xxxx references. If none exists, create a new knowledge page. Keep the test focused on detection and evaluation.
+6. Normalize background vs test logic: Add platform background as @MASTG-KNOW-xxxx references. If none exists, create a new knowledge page. Keep the test focused on detection and evaluation.
 
-7) Link general concepts to Document: Some content belongs in the Document chapter. For example, general cryptography concepts such as symmetric/asymmetric encryption, hashing, signing, etc. If the knowledge is still in `Document/`, link to it.
+7. Link general concepts to Document: Some content belongs in the Document chapter. For example, general cryptography concepts such as symmetric/asymmetric encryption, hashing, signing, etc. If the knowledge is still in `Document/`, link to it.
 
-Example: ["Post Quantum"](https://mas.owasp.org/MASTG/Document/0x04g-Testing-Cryptography/#post-quantum)
+   **Example:** ["Post Quantum"](https://mas.owasp.org/MASTG/Document/0x04g-Testing-Cryptography/#post-quantum)
 
-8) Avoid duplication: You may summarize, but focus the test on how to detect the issue in Android/iOS and why it matters for this test.
+8. Avoid duplication: You may summarize, but focus the test on how to detect the issue in Android/iOS and why it matters for this test.
 
-9) Link mitigations: Ensure there is a clear mitigation in best-practices; add the reference in front matter (field defined in `mastg-test.instructions.md`).
+9. Link mitigations: Ensure there is a clear mitigation in best practices; add the reference in front matter (field defined in `mastg-test.instructions.md`).
 
-10) Trim non-essential parts: If parts of the v1 test aren’t relevant, remove them and note it in the ticket.
+10. Trim non-essential parts: If parts of the v1 test aren’t relevant, remove them and note it in the ticket.
 
-**Example:** In MASTG-TEST-0017, what’s written in dynamic analysis does not make sense: why should we validate that `setUserAuthenticationValidityDurationSeconds` are for real (we are not testing if Android features work; we assume they do). Maybe we could also use dynamic analysis but following a different approach.
+    **Example:** In MASTG-TEST-0017, what’s written in dynamic analysis does not make sense: why should we validate that `setUserAuthenticationValidityDurationSeconds` is for real (we are not testing if Android features work; we assume they do). Perhaps we could also employ dynamic analysis, but using a different approach.
 
-11) Fill missing links to docs and developer references as needed.
+11. Fill missing links to docs and developer references as needed.
 
-**Example:** this test and the referenced section both were missing links to [https://developer.android.com/](https://developer.android.com/) 
+    **Example:** this test and the referenced section both were missing links to [https://developer.android.com/](https://developer.android.com/) 
 
 ## Porting considerations
 
 V1 tests often include techniques, tools, and theory/knowledge. Move that to the right place (or create it) and reference it (for example, @MASTG-TECH-0002, @MASTG-KNOW-0011, @MASTG-TOOL-0097). In the test body, use `@` prefixes; in YAML front matter, use bare IDs without `@`. For exact field names and section structure, see `mastg-test.instructions.md`.
 
-Theory must be always linked to the @MASTG-KNOW-xxxx components. If the theory is not covered yet, create a new knowledge page. If it's a general concept, it may still belong in the Document chapter under 0x04.
+Theory must always be linked to the @MASTG-KNOW-xxxx components. If the theory is not covered yet, create a new knowledge page. If it's a general concept, it may still belong in the Document chapter under 0x04.
 
 Review existing content and **UPDATE** it. Especially references to Android/iOS versions and things you know have changed since the text was written.
 
 #### Best practices linkage
 
-Best practices are platform specific and can be linked in the test metadata. Our automation creates a “Mitigations” section automatically.
+Best practices are platform-specific and can be linked in the test metadata. Our automation creates a “Mitigations” section automatically.
 
 1. Check if a best practice already exists in `best-practices/` folder
-2. If it doesn’t exist yet, create it new in `best-practices/` using the next available ID
+2. If it doesn’t exist yet, create it new in `best-practices/` using the following available ID
 3. Add a reference to the best practices with @MASTG-BEST-xxxx
 
 #### Deprecating V1 tests
@@ -131,44 +131,44 @@ Some findings apply only with stronger attacker capabilities (for example, root/
 
 Indicate in the test whether exploitation requires root/jailbreak.
 
-> *On devices supporting file-based encryption (FBE) ↗, snapshots are stored in the /data/system\_ce/\<USER\_ID\>/\<IMAGE\_FOLDER\_NAME\> folder. \<IMAGE\_FOLDER\_NAME\> depends on the vendor but most common names are snapshots and recent\_images. If the device doesn't support FBE, the /data/system/\<IMAGE\_FOLDER\_NAME\> folder is used.*
+> *On devices supporting file-based encryption (FBE) ↗, snapshots are stored in the /data/system\_ce/\<USER\_ID\>/\<IMAGE\_FOLDER\_NAME\> folder. \<IMAGE\_FOLDER\_NAME\> depends on the vendor, but the most common names are snapshots and recent\_images. If the device doesn't support FBE, the /data/system/\<IMAGE\_FOLDER\_NAME\> folder is used.*
 
 Accessing these folders and the snapshots requires root.
 
 EXAMPLE: cleartext configured globally in NSC. No need for root, network/mitm: yes
 
-What other things to consider here?
+What other things should we consider here?
 
 - **binary**: possible just because the attacker has the binary (decrypted on iOS)
 - **app**: another app on the device with the right permissions (e.g. full access to external storage)
-- **mitm**: a network based attacker capable of performing MITM
+- **mitm**: a network-based attacker capable of performing MITM
 - **user computer**: the user using adb
-- **user UI**: using the app's or another app’s UI, e.g. third party file manager;
+- **user UI**: using the app's or another app’s UI, e.g. third-party file manager;
 - **user confirmation**: e.g. pasteboard confirmation
 
 ### Code Snippets
 
 If the v1 test has snippets that inspire a demo, prefer Kotlin and Swift for new examples (avoid Java/Objective-C). You can create a demo with `status: draft` and finish later. See `mastg-demo.instructions.md` for demo authoring.
 
-You can create a demo **status: draft** and come back later to it. Just to ensure we extracted everything from V1. Create a ticket **"Finish Demo Draft MASTG-DEMO-xxxx"**
+You can create a demo **status: draft** and come back to it later. To ensure we extracted everything from V1. Create a ticket **"Finish Demo Draft MASTG-DEMO-xxxx"**
 
 - [https://github.com/WithSecureLabs/sieve/](https://github.com/WithSecureLabs/sieve/)
 - Ovaa
 - MASTG playground
 - [https://mas.owasp.org/MASTG/apps/](https://mas.owasp.org/MASTG/apps/)
 
-List of apps to get ideas from, as inspiration. You may include "inspired by" to ref to the original source whenever our new content is similar enough.
+List of apps to get ideas from, as inspiration. You may include "inspired by" to reference the source whenever our new content is similar enough.
 
 ### Notes (keep in mind while porting)
 
-- A test must not describe the general problem again (that’s the Weakness’ job). Keep the test focused on detection and evaluation.
+- A test must not describe the general problem again (that’s the Weakness’s job). Keep the test focused on detection and evaluation.
 - If you find an edge case, consider whether it deserves a separate test with distinct steps/evaluation.
 
 ### OS version
 
-**For Android:** We have agreed on supporting the **current version \- 5**. This gives a roughly 90% adoption rate on average. See [https://apilevels.com/](https://apilevels.com/) 
+**For Android:** We have agreed on supporting the **current version \- 5**. This yields an average adoption rate of roughly 90%. See [https://apilevels.com/](https://apilevels.com/) 
 
-If a test is no longer applicable for some OS versions, add an applicability note so testers can discard it when not relevant.
+If a test is no longer applicable for specific OS versions, add an applicability note so testers can discard it when it is not relevant.
 
 Avoid creating demos for unsupported versions.
 

--- a/.github/instructions/porting-mastg-v1-tests-to-v2.instructions.md
+++ b/.github/instructions/porting-mastg-v1-tests-to-v2.instructions.md
@@ -108,7 +108,7 @@ Review existing content and **UPDATE** it. Especially references to Android/iOS 
 Best practices are platform-specific and can be linked in the test metadata. Our automation creates a “Mitigations” section automatically.
 
 1. Check if a best practice already exists in `best-practices/` folder
-2. If it doesn’t exist yet, create it new in `best-practices/` using the following available ID
+2. If it doesn’t exist yet, create it new in `best-practices/` using the next available ID.
 3. Add a reference to the best practices with @MASTG-BEST-xxxx
 
 #### Deprecating V1 tests


### PR DESCRIPTION
## Description

Improve grammar and clarity in markdown instructions.

The target branch is **not** the main branch.