### PR TITLE
Fix punctuation and formatting in Foreword section

### DIFF
--- a/Document/0x01-Foreword.md
+++ b/Document/0x01-Foreword.md
@@ -1,19 +1,17 @@
 # Foreword
 
-Welcome to the OWASP Mobile Application Security Testing Guide. Feel free to explore the existing content, but do note that it may change at any time. New APIs and best practices are introduced in iOS and Android with every major (and minor) release and also vulnerabilities are found every day.
+Welcome to the OWASP Mobile Application Security Testing Guide. Feel free to explore the existing content, but do note that it may change at any time. New APIs and best practices are introduced in iOS and Android with every major (and minor) release, and vulnerabilities are found every day.
 
-If you have feedback or suggestions, or want to contribute, create an issue on GitHub or ping us on Slack. See the README for instructions:
-
-<https://www.github.com/OWASP/mastg/>
+If you have feedback or suggestions, or want to contribute, create an issue on GitHub or ping us on Slack. See the [README](https://www.github.com/OWASP/mastg/) for instructions.
 
 **squirrel (noun plural): Any arboreal sciurine rodent of the genus Sciurus, such as S. vulgaris (red squirrel) or S. carolinensis (grey squirrel), having a bushy tail and feeding on nuts, seeds, etc.**
 
-On a beautiful summer day, a group of ~7 young men, a woman, and approximately three squirrels met in a Woburn Forest villa during the OWASP Security Summit 2017. So far, nothing unusual. But little did you know, within the next five days, they would redefine not only mobile application security, but the very fundamentals of book writing itself (ironically, the event took place near Bletchley Park, once the residence and work place of the great Alan Turing).
+On a beautiful summer day, a group of ~7 young men, a woman, and approximately three squirrels met in a Woburn Forest villa during the OWASP Security Summit 2017. So far, nothing unusual. But little did you know, within the next five days, they would redefine not only mobile application security but the very fundamentals of book writing itself (ironically, the event took place near Bletchley Park, once the residence and workplace of the great Alan Turing).
 
-Or maybe that's going too far. But at least, they produced a proof-of-concept for an unusual security book. The Mobile Application Security Testing Guide (MASTG) is an open, agile, crowd-sourced effort, made of the contributions of dozens of authors and reviewers from all over the world.
+Or maybe that's going too far, but at least they produced a proof-of-concept for an unusual security book. The Mobile Application Security Testing Guide (MASTG) is an open, agile, crowd-sourced effort made of the contributions of dozens of authors and reviewers from all over the world.
 
-Because this isn't a normal security book, the introduction doesn't list impressive facts and data proving importance of mobile devices in this day and age. It also doesn't explain how mobile application security is broken, and why a book like this was sorely needed, and the authors don't thank their beloved ones without whom the book wouldn't have been possible.
+Because this isn't a normal security book, the introduction doesn't list impressive facts and data proving the importance of mobile devices in this day and age. It also doesn't explain how mobile application security is broken, and why a book like this was sorely needed, and the authors don't thank their beloved ones without whom the book wouldn't have been possible.
 
-We do have a message to our readers however! The first rule of the OWASP Mobile Application Security Testing Guide is: Don't just follow the OWASP Mobile Application Security Testing Guide. True excellence at mobile application security requires a deep understanding of mobile operating systems, coding, network security, cryptography, and a whole lot of other things, many of which we can only touch on briefly in this book. Don't stop at security testing. Write your own apps, compile your own kernels, dissect mobile malware, learn how things tick. And as you keep learning new things, consider contributing to the MASTG yourself! Or, as they say: "Do a pull request".
+We do have a message to our readers, however! The first rule of the OWASP Mobile Application Security Testing Guide is: Don't just follow the OWASP Mobile Application Security Testing Guide. True excellence at mobile application security requires a deep understanding of mobile operating systems, coding, network security, cryptography, and a whole lot of other things, many of which we can only touch on briefly in this book. Don't stop at security testing. Write your own apps, compile your own kernels, dissect mobile malware, learn how things tick. And as you keep learning new things, consider contributing to the MASTG yourself! Or, as they say: "Do a pull request".
 
 <img src="Images/summit-team.jpg" width="100%" />


### PR DESCRIPTION
corrected punctuation and formatting

## Description

This PR improves the Foreword section of the MASTG documentation by:
- adding missing commas
- improves readabilty
- fixing the readme link markdown

No technical changes; this is purely a documentation improvement.

### AI tool Disclosure

- [x] my contribution does not include ai generated content

- [x] i have read the guidelines
