### PR TITLE
ci: declare least-privilege `GITHUB_TOKEN` permissions on the 10 remaining workflows

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -14,6 +14,9 @@ on:
       - 'demos/**'
       - '.github/workflows/build-android-demos.yml'
 
+permissions:
+  contents: read
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-ios-demos.yml
+++ b/.github/workflows/build-ios-demos.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - 'demos/**'
       - '.github/workflows/build-ios-demos.yml'
+
+permissions:
+  contents: read
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-duplicate-ids.yml
+++ b/.github/workflows/check-duplicate-ids.yml
@@ -10,6 +10,11 @@ on:
       - 'tools/**'
       - 'techniques/**'
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   check-duplicates:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-website-build.yml
+++ b/.github/workflows/check-website-build.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: OWASP/mas-website/.github/workflows/build-website-reusable.yml@main

--- a/.github/workflows/docgenerator.yml
+++ b/.github/workflows/docgenerator.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - 'Document/**.md'
 
+permissions:
+  contents: read
+
 jobs:
   Generate-Checklists:
     runs-on: ubuntu-latest
@@ -83,6 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [Generate-Checklists]
     if: startsWith(github.ref, 'refs/tags/') && (github.actor == 'cpholguera' || github.actor == 'sushi2k')
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
 

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   markdown-lint-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/spell-checker-pr.yml
+++ b/.github/workflows/spell-checker-pr.yml
@@ -3,6 +3,10 @@ name: Spell Checker (PR)
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/url-checker-pr.yml
+++ b/.github/workflows/url-checker-pr.yml
@@ -2,6 +2,9 @@ name: URL Checker (PR)
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/url-checker.yml
+++ b/.github/workflows/url-checker.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #3805.

Supersedes #3801, #3802, #3803, #3804 (which were auto-closed by `pr-issue-assignment-check` for not referencing an issue). All four of those changes plus six more are bundled here.

## Changes per file

Workflow-level `contents: read`:

- `build-android-demos.yml`
- `build-ios-demos.yml`
- `check-website-build.yml`
- `markdown-linter.yml`
- `spell-checker.yml`
- `url-checker.yml`
- `url-checker-pr.yml`

Workflow-level `contents: read` plus extra read scope (uses `gh pr diff`):

- `spell-checker-pr.yml` adds `pull-requests: read`

Workflow-level `contents: read` plus comment-write scopes:

- `check-duplicate-ids.yml` adds `pull-requests: write` and `issues: write` because it uses `actions/github-script` to post review comments and fall back to issue comments.

Per-job permissions (workflow has a privileged step):

- `docgenerator.yml` gets workflow-level `contents: read`, plus the `release` job (tag-gated, runs `softprops/action-gh-release`) is given `contents: write`. The `Generate-Checklists` job inherits read-only.

The other 6 workflows in `.github/workflows/` (`codeql-analysis.yml`, `issue-assignment-bot.yml`, `issues-messenger-bot.yml`, `labeler.yml`, `moderator.yml`, `pr-issue-assignment-check.yml`) already declare their own permissions blocks and are out of scope.

## Why

Standard supply-chain hygiene. CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is the canonical motivation: a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Per-workflow caps bound that runtime authority irrespective of repo or org default, give drift protection if the default ever widens, and register with OpenSSF Scorecard's `Token-Permissions` check (which only credits explicit per-workflow declarations).

YAML validated locally with `yaml.safe_load` on each touched file.