### PR TITLE
ci: declare workflow-level `contents: read` on 4 PR-side checkers

### DIFF
--- a/.github/workflows/check-duplicate-ids.yml
+++ b/.github/workflows/check-duplicate-ids.yml
@@ -10,6 +10,9 @@ on:
       - 'tools/**'
       - 'techniques/**'
 
+permissions:
+  contents: read
+
 jobs:
   check-duplicates:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   markdown-lint-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/spell-checker-pr.yml
+++ b/.github/workflows/spell-checker-pr.yml
@@ -3,6 +3,9 @@ name: Spell Checker (PR)
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/url-checker-pr.yml
+++ b/.github/workflows/url-checker-pr.yml
@@ -2,6 +2,9 @@ name: URL Checker (PR)
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Four PR-time validation workflows just validate the diff:

- `check-duplicate-ids.yml`
- `markdown-linter.yml`
- `spell-checker-pr.yml`
- `url-checker-pr.yml`

None of them call the GitHub API beyond checkout, so workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.