### PR TITLE
Improve demo test writing guidelines and remove metadata tools

### DIFF
--- a/.github/instructions/mastg-demo.instructions.md
+++ b/.github/instructions/mastg-demo.instructions.md
@@ -83,24 +83,6 @@ title: Common Uses of Insecure Random APIs
 
 The mobile platform. One of: `ios`, `android`.
 
-### tools
-
-Tools used in the demo.
-
-When available, prefer referencing official tool IDs from <https://mas.owasp.org/MASTG/tools/> (for example, `MASTG-TOOL-0031`). If an official ID is not available, you may use a well-known tool name (for example, `semgrep`).
-
-Example:
-
-```md
-tools: [MASTG-TOOL-0031]
-```
-
-Example without an official ID:
-
-```md
-tools: [semgrep]
-```
-
 ### code
 
 The language(s) in which the samples are written. This must not include the reverse-engineered files (e.g. `.java`, `.asm`, etc.)
@@ -172,18 +154,34 @@ The snippet below shows sample code that sends sensitive data over the network u
 
 ### Steps
 
-A concise write-up following all steps from the linked test, including placeholders for testing code and scripts (for example, SAST rules, `run.sh`).
+A concise write-up of every action needed to reproduce the test result. Always include placeholders for any testing code and scripts involved (for example, SAST rules, `run.sh`, `hooks.json`).
 
-Example:
+Always reference official tool IDs (for example, `@MASTG-TOOL-0110`) and technique IDs (for example, `@MASTG-TECH-0005`). Only fall back to a well-known tool name when no official ID exists.
+
+Use **prose** for single-command static analysis (for example, a semgrep rule run):
 
 ```md
 ## Steps
 
-Let's run our semgrep rule against the sample code.
+Let's run our @MASTG-TOOL-0110 rule against the sample code.
 
-{{ ../../../../rules/mastg-android-non-random-use.yaml }}
+{{ ../../../../rules/mastg-android-random-apis-insufficient-entropy.yml }}
 
 {{ run.sh }}
+```
+
+Use a **numbered list** for multi-step or interactive workflows (for example, dynamic analysis with Frida):
+
+```md
+## Steps
+
+1. Install the app on a device (@MASTG-TECH-0005).
+2. Make sure you have @MASTG-TOOL-0145 installed on your machine and the frida-server running on the device.
+3. Run `run.sh` to spawn the app with Frida.
+4. Tap the **Start** button.
+5. Stop the script by pressing `Ctrl+C` and/or `q` to quit the Frida CLI.
+
+{{ hooks.json # run.sh }}
 ```
 
 ### Observation

--- a/demos/android/MASVS-CRYPTO/MASTG-DEMO-0017/MASTG-DEMO-0017.md
+++ b/demos/android/MASVS-CRYPTO/MASTG-DEMO-0017/MASTG-DEMO-0017.md
@@ -2,8 +2,7 @@
 platform: android
 title: Use of Hardcoded AES Key in SecretKeySpec with semgrep
 id: MASTG-DEMO-0017
-test: MASTG-TEST-0212
-tools: [semgrep]
+test: MASTG-TEST-0212semgrep]
 code: [java]
 ---
 

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0078/MASTG-DEMO-0078.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0078/MASTG-DEMO-0078.md
@@ -3,8 +3,7 @@ platform: android
 title: App Leaking Sensitive Data via Notifications
 id: MASTG-DEMO-0078
 code: [kotlin]
-test: MASTG-TEST-0315
-tools: [MASTG-TOOL-0110]
+test: MASTG-TEST-0315MASTG-TOOL-0110]
 ---
 
 ## Sample

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0103/MASTG-DEMO-0103.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0103/MASTG-DEMO-0103.md
@@ -3,8 +3,7 @@ platform: android
 title: Missing Overlay Protection on a Sensitive View
 id: MASTG-DEMO-0103
 code: [kotlin, java]
-test: MASTG-TEST-0340
-tools: [semgrep]
+test: MASTG-TEST-0340semgrep]
 ---
 
 ## Sample

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0104/MASTG-DEMO-0104.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0104/MASTG-DEMO-0104.md
@@ -3,8 +3,7 @@ platform: android
 title: App Requesting SYSTEM_ALERT_WINDOW Permission
 id: MASTG-DEMO-0104
 code: [xml]
-test: MASTG-TEST-0340
-tools: [semgrep]
+test: MASTG-TEST-0340semgrep]
 kind: info
 ---
 

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0105/MASTG-DEMO-0105.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0105/MASTG-DEMO-0105.md
@@ -3,8 +3,7 @@ platform: android
 title: Activity-Level Overlay Protection Using setHideOverlayWindows
 id: MASTG-DEMO-0105
 code: [kotlin, java, xml]
-test: MASTG-TEST-0340
-tools: [semgrep]
+test: MASTG-TEST-0340semgrep]
 kind: pass
 ---
 

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0087/MASTG-DEMO-0087.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0087/MASTG-DEMO-0087.md
@@ -3,8 +3,7 @@ platform: android
 title: Uses of Root Detection Techniques with Semgrep
 id: MASTG-DEMO-0087
 code: [kotlin, xml]
-test: MASTG-TEST-0324
-tools: [MASTG-TOOL-0110]
+test: MASTG-TEST-0324MASTG-TOOL-0110]
 kind: pass
 ---
 

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0088/MASTG-DEMO-0088.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0088/MASTG-DEMO-0088.md
@@ -3,8 +3,7 @@ platform: android
 title: Runtime Detection of Root Detection Mechanisms
 id: MASTG-DEMO-0088
 code: [kotlin]
-test: MASTG-TEST-0325
-tools: [MASTG-TOOL-0145]
+test: MASTG-TEST-0325MASTG-TOOL-0145]
 ---
 
 ## Sample


### PR DESCRIPTION
Enhance the guidelines for writing demo tests by clarifying the structure and emphasizing the use of official tool and technique IDs. Remove outdated metadata tools references to streamline the documentation.

