### PR TITLE
fix file refs

### DIFF
--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0114/MASTG-DEMO-0114.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0114/MASTG-DEMO-0114.md
@@ -19,7 +19,7 @@ Notes about the checks performed:
 - The sample avoids Play Integrity checks (@MASTG-KNOW-0035) because they require Play Console configuration and server-side verification, which breaks the self-contained requirement for MASTG demos.
 - The manifest declares `READ_PHONE_STATE` and `READ_PHONE_NUMBERS` so the runtime permission prompts can be shown before querying telephony values, and it includes `<queries>` entries for package visibility checks.
 
-{{ MastgTest.kt # MastgTest_reversed.java }}
+{{ MastgTest.kt # AndroidManifest.xml }}
 
 ## Steps
 


### PR DESCRIPTION
This pull request makes a minor update to the documentation for the MASTG-DEMO-0114 Android demo. The change corrects a code reference in the "Notes about the checks performed" section to point to the appropriate file.

- Updated the code reference from `MastgTest_reversed.java` to `AndroidManifest.xml` in the documentation to accurately reflect the relevant file for manifest-related checks.