### PR TITLE
Port MASTG-TEST-0048: Testing Reverse Engineering Tools Detection (android)

### DIFF
--- a/tests/android/MASVS-RESILIENCE/MASTG-TEST-0048.md
+++ b/tests/android/MASVS-RESILIENCE/MASTG-TEST-0048.md
@@ -8,6 +8,9 @@ title: Testing Reverse Engineering Tools Detection
 masvs_v1_levels:
 - R
 profiles: [R]
+status: deprecated
+covered_by: [MASTG-TEST-0341]
+deprecation_note: "New version available in MASTG V2"
 ---
 
 ## Effectiveness Assessment


### PR DESCRIPTION
Mark the test as deprecated and reference the new version.

This PR closes #3013 
