### PR TITLE
fix metadata

### DIFF
--- a/demos/android/MASVS-CRYPTO/MASTG-DEMO-0017/MASTG-DEMO-0017.md
+++ b/demos/android/MASVS-CRYPTO/MASTG-DEMO-0017/MASTG-DEMO-0017.md
@@ -2,7 +2,7 @@
 platform: android
 title: Use of Hardcoded AES Key in SecretKeySpec with semgrep
 id: MASTG-DEMO-0017
-test: MASTG-TEST-0212semgrep]
+test: MASTG-TEST-0212
 code: [java]
 ---
 

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0078/MASTG-DEMO-0078.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0078/MASTG-DEMO-0078.md
@@ -3,7 +3,7 @@ platform: android
 title: App Leaking Sensitive Data via Notifications
 id: MASTG-DEMO-0078
 code: [kotlin]
-test: MASTG-TEST-0315MASTG-TOOL-0110]
+test: MASTG-TEST-0315
 ---
 
 ## Sample

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0103/MASTG-DEMO-0103.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0103/MASTG-DEMO-0103.md
@@ -3,7 +3,7 @@ platform: android
 title: Missing Overlay Protection on a Sensitive View
 id: MASTG-DEMO-0103
 code: [kotlin, java]
-test: MASTG-TEST-0340semgrep]
+test: MASTG-TEST-0340
 ---
 
 ## Sample

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0104/MASTG-DEMO-0104.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0104/MASTG-DEMO-0104.md
@@ -3,7 +3,7 @@ platform: android
 title: App Requesting SYSTEM_ALERT_WINDOW Permission
 id: MASTG-DEMO-0104
 code: [xml]
-test: MASTG-TEST-0340semgrep]
+test: MASTG-TEST-0340
 kind: info
 ---
 

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0105/MASTG-DEMO-0105.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0105/MASTG-DEMO-0105.md
@@ -3,7 +3,7 @@ platform: android
 title: Activity-Level Overlay Protection Using setHideOverlayWindows
 id: MASTG-DEMO-0105
 code: [kotlin, java, xml]
-test: MASTG-TEST-0340semgrep]
+test: MASTG-TEST-0340
 kind: pass
 ---
 

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0087/MASTG-DEMO-0087.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0087/MASTG-DEMO-0087.md
@@ -3,7 +3,7 @@ platform: android
 title: Uses of Root Detection Techniques with Semgrep
 id: MASTG-DEMO-0087
 code: [kotlin, xml]
-test: MASTG-TEST-0324MASTG-TOOL-0110]
+test: MASTG-TEST-0324
 kind: pass
 ---
 

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0088/MASTG-DEMO-0088.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0088/MASTG-DEMO-0088.md
@@ -3,7 +3,7 @@ platform: android
 title: Runtime Detection of Root Detection Mechanisms
 id: MASTG-DEMO-0088
 code: [kotlin]
-test: MASTG-TEST-0325MASTG-TOOL-0145]
+test: MASTG-TEST-0325
 ---
 
 ## Sample


### PR DESCRIPTION
This pull request makes minor corrections to several Android demo markdown files by fixing the `test` field values. Specifically, it removes extraneous tool identifiers (such as `semgrep` or `MASTG-TOOL-xxxx`) from the `test` fields, ensuring that only the appropriate test IDs are specified.
