### PR TITLE
Add build block to Android demo workflow

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -255,6 +255,7 @@ jobs:
           insert_block sections
           insert_block android
           insert_block libs
+          insert_block build
 
           echo "Building APK for $demo"
 


### PR DESCRIPTION
Closes #3816

This pull request makes a small change to the Android demo build workflow. It adds a new block to the build process to ensure the `build` section is included during the APK build step.