### PR TITLE
fix scripts

### DIFF
--- a/.github/skills/mastg-assign-ids/scripts/find_fakes.sh
+++ b/.github/skills/mastg-assign-ids/scripts/find_fakes.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-CHANGED=$(git diff --name-only origin/master...HEAD | grep -v "^\.github/")
+CHANGED=$({ git diff --name-only origin/master...HEAD; git diff --cached --name-only --diff-filter=d; } | sort -u | grep -v "^\.github/")
 
 # Matches both standard fake IDs (MASTG-TYPE-0x##) and non-standard ones
 # where the suffix contains lowercase hex chars (e.g. MASTG-BEST-00ea).

--- a/.github/skills/mastg-assign-ids/scripts/fix_ids.py
+++ b/.github/skills/mastg-assign-ids/scripts/fix_ids.py
@@ -35,14 +35,18 @@ def main():
         old, new = arg.split("=", 1)
         replacements.append((old, new))
 
-    result = subprocess.run(
+    committed = subprocess.run(
         ["git", "diff", "--name-only", "--diff-filter=d", "origin/master...HEAD"],
         capture_output=True, text=True, check=True,
-    )
-    files = [
-        p for p in result.stdout.splitlines()
+    ).stdout.splitlines()
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=d"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    files = sorted({
+        p for p in committed + staged
         if not p.startswith(".github/") and os.path.isfile(p)
-    ]
+    })
 
     for path in files:
         with open(path) as f:

--- a/.github/skills/mastg-assign-ids/scripts/verify.sh
+++ b/.github/skills/mastg-assign-ids/scripts/verify.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-CHANGED=$(git diff --name-only origin/master...HEAD | grep -v "^\.github/")
+CHANGED=$({ git diff --name-only origin/master...HEAD; git diff --cached --name-only --diff-filter=d; } | sort -u | grep -v "^\.github/")
 
 # Matches both standard fake IDs (MASTG-TYPE-0x##) and non-standard ones
 # where the suffix contains lowercase hex chars (e.g. MASTG-BEST-00ea).


### PR DESCRIPTION
## Bug fixes in `mastg-assign-ids` skill scripts

All three scripts (`fix_ids.py`, `verify.sh`, `find_fakes.sh`) scoped their work to `git diff --name-only origin/master...HEAD`, which only covers **committed** changes. After `git mv` (a **staged** rename, not yet committed), this breaks in two ways:

- **`fix_ids.py`** — the old paths no longer exist on disk, `os.path.isfile()` silently skips them, and the new paths aren't in the committed diff at all → `id:` fields go unreplaced.
- **`verify.sh`** — greps the old (now-missing) paths after `git mv`; `xargs grep` errors are suppressed by `|| true`, so `$HITS` is empty → false "OK" even when fake IDs still exist.

**Fix applied to all three scripts:** also pull in staged changes via `git diff --cached --name-only --diff-filter=d` and merge the two path lists.

| Script | Bug | Fix |
|--------|-----|-----|
| `fix_ids.py` | Only scanned committed diff; staged renames (new paths) were invisible → `id:` fields left unreplaced | Also pull `git diff --cached` and merge the two path sets |
| `verify.sh` | Grepped old (now-missing) paths after `git mv`; errors suppressed by `\|\| true` → false "OK" | Same: include staged paths so it greps the actual files on disk |
| `find_fakes.sh` | Same scoping issue if run after renames | Same fix for consistency |
