### PR TITLE
Draft: v2.1 specs

### DIFF
--- a/.github/instructions/mastg-demo.instructions.md
+++ b/.github/instructions/mastg-demo.instructions.md
@@ -344,6 +344,56 @@ Review each of the reported instances.
 Note that line 37 did not trigger the rule because the random number is generated using `SecureRandom`, which is a secure random number generator.
 ```
 
+### Confirming the Vulnerability
+
+Every demo MUST include a part that shows how to confirm or exploit the vulnerability at runtime, referencing the techniques (`@MASTG-TECH-XXXX`) and tools (`@MASTG-TOOL-XXXX`) a tester would use. Only "attacker" apps are excluded from this requirement, since they are already the embodiment of the attack.
+
+- Add it as a `### Exploitation` (or `### Confirm the Exposure`) subsection at the end of the `## Evaluation` section. A dedicated heading is preferred, but it may also be woven into the Evaluation prose when a heading feels forced.
+- Always reference the relevant technique by ID (for example, "You can use @MASTG-TECH-0148 to interact with the `ContentProvider` and confirm the injection") and include the exact, copyable commands.
+- Make the confirmation observable. When possible, design the sample so the result is visible in the app (for example, the `mastgTest()` output reflects the state the attacker changed) or in a tool output (for example, `adb logcat`).
+
+See @MASTG-DEMO-0102 (dedicated `### Exploitation` heading) and @MASTG-DEMO-0100 (woven into the Evaluation prose) for reference.
+
+### Fix
+
+Every demo for a `fail` case SHOULD include a `## Fix` section after `## Evaluation` that explains how to remediate the finding.
+
+- Describe only the options that apply to the specific component type and vulnerability shown in the demo.
+- Use bold `**Option N: …**` headings for each option.
+- **Always include Option 1** as the recommended minimal fix (for example, `android:exported="false"` or `android:permission`).
+- For each option, include the exact manifest or code change and a copyable command that confirms the fix is effective (for example, an `adb` command that now fails with a `SecurityException`).
+- Add extra options only when they reflect realistic use cases (for example, a signature-level permission for cross-app trust, or a runtime caller check as defence-in-depth).
+- If an additional non-component fix applies (for example, removing credentials from logs), append it as a separate bold paragraph rather than a numbered option.
+- End with a brief explanation of **why** any naive protection (for example, a client-side PIN gate) is insufficient, so the reader understands the root cause.
+
+Example structure:
+
+```markdown
+## Fix
+
+There are two ways to fix this, depending on whether `<Component>` needs to be reachable by external apps.
+
+**Option 1: Set `android:exported="false"` (recommended)**
+
+…manifest snippet…
+
+…adb command confirming the fix…
+
+Explanation of when this is the right choice.
+
+**Option 2: Keep `android:exported="true"` but enforce a `android:permission`**
+
+…manifest snippet…
+
+…adb command confirming the fix…
+
+Explanation of when this is the right choice.
+
+**Why not rely on a client-side control?**
+
+Brief explanation of why the broken pattern in the sample is insufficient.
+```
+
 ## Code Samples
 
 Code samples for demos **must be** **created using one of our test apps** to ensure consistency across demos and facilitate the review process:

--- a/.github/instructions/mastg-test.instructions.md
+++ b/.github/instructions/mastg-test.instructions.md
@@ -204,6 +204,27 @@ Example:
 Android apps sometimes use insecure pseudorandom number generators (PRNGs) such as `java.util.Random`, which is essentially a linear congruential generator. This type of PRNG generates a predictable sequence of numbers for any given seed value, making the sequence reproducible and insecure for cryptographic use. In particular, `java.util.Random` and `Math.random()` ([the latter](https://franklinta.com/2014/08/31/predicting-the-next-math-random-in-java/) simply calling `nextDouble()` on a static `java.util.Random` instance) produce identical number sequences when initialized with the same seed across all Java implementations.
 ```
 
+#### Example Attack Scenario
+
+The Overview MUST include an `**Example Attack Scenario:**` block. It helps the reader understand how an attacker would actually abuse the issue and what the real-world consequence is. Place it at the end of the Overview, immediately before the `## Steps` section.
+
+Write it as a short setup sentence followed by a numbered list of concrete attacker steps that ends with the impact (for example, data exposure, authentication bypass, account takeover, or code execution). Refer to relevant techniques with their `@MASTG-TECH-XXXX` IDs where helpful.
+
+See @MASTG-TEST-0250 and @MASTG-TEST-0252 for reference.
+
+Example:
+
+```md
+**Example Attack Scenario:**
+
+Suppose a banking app protects its account screen behind a login activity but also declares an account-details activity that is exported.
+
+1. An attacker reverse engineers the app and finds the exported activity.
+2. The attacker writes a malicious app that starts it directly by its component name.
+3. The account screen opens without going through the login activity.
+4. The victim's account data is exposed, bypassing authentication entirely.
+```
+
 ### Steps
 
 A test must include at least one step. Steps can be static, dynamic, manual, or, in very specific cases, a combination of these.


### PR DESCRIPTION
```
  master ──┐
           └─ remove-v2.1-specs (−464)       ← PR #3872: clean v2 baseline
                └─ v2.1-specs (+71)          ← PR #3873: v2.1 spec in instruction files
                     └─ migrate-demos-tests-to-v2.1-specs (+393)  ← PR #3877: adopt v2.1 spec in demos/tests

```


## Description

Introduce v2.1 Specs. Adds work removed from #3872

Once PR #3872  is merged, this re-targets the updated master and shows the clean +71 v2.1 diff.
The remaining +393 (14 demo/test files) moved into #3877.

**This should get merged after v2 release or we should target a feature branch (e.g. `OWASP:v2.1`).**

---

## AI Tool Disclosure

- **AI tools used:**Opus 4.8