### PR TITLE
Fix broken code block on MASTG-DEMO-0102 (Java code)

### DIFF
--- a/demos/android/MASVS-CODE/MASTG-DEMO-0102/MASTG-DEMO-0102.md
+++ b/demos/android/MASVS-CODE/MASTG-DEMO-0102/MASTG-DEMO-0102.md
@@ -41,7 +41,7 @@ The vulnerable data flow is visible in the reversed code. The provider registers
 ```java
 $this$uriMatcher_u24lambda_u240.addURI(AUTHORITY, "students/#", 2);
 $this$uriMatcher_u24lambda_u240.addURI(AUTHORITY, "students/filter/*", 3);
-````
+```
 
 For the path-based case, the provider reads a user-controlled URI segment and appends it directly into the SQL query:
 


### PR DESCRIPTION
This PR closes #3889

## Description

There is a broken code block in **MASTG-DEMO-0102** on lines 41-44 with root cause on line 44 due an extra ``` character,

This PR fixes it.

---

## AI Tool Disclosure

Check exactly one option.

- [x] This contribution does not include AI-generated content.
- [ ] This contribution includes AI-generated content.

---

## Contributor Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I followed the project style guide.
- [x] I validated the technical correctness of my changes and understand the topic.
- [x] This PR adds clear value and is not spam or low-effort content.