### PR TITLE
Port MASTG-TEST-0093: Testing Obfuscation (iOS) to v2

### DIFF
--- a/best-practices/MASTG-BEST-0029.md
+++ b/best-practices/MASTG-BEST-0029.md
@@ -3,7 +3,7 @@ title: Implementing Resilience and RASP Signals
 alias: implementing-resilience-and-rasp-signals
 id: MASTG-BEST-0029
 platform: generic
-knowledge: [MASTG-KNOW-0027, MASTG-KNOW-0028, MASTG-KNOW-0029, MASTG-KNOW-0030, MASTG-KNOW-0031, MASTG-KNOW-0032, MASTG-KNOW-0033, MASTG-KNOW-0034, MASTG-KNOW-0035]
+knowledge: [MASTG-KNOW-0027, MASTG-KNOW-0028, MASTG-KNOW-0029, MASTG-KNOW-0030, MASTG-KNOW-0031, MASTG-KNOW-0032, MASTG-KNOW-0033, MASTG-KNOW-0034, MASTG-KNOW-0035, MASTG-KNOW-0089]
 status: placeholder
 note: Resilience controls and RASP (Runtime Application Self-Protection) style checks are defense in depth measures that raise attacker cost by detecting risky environments and runtime tampering. They do not replace secure design and they are inherently bypassable, so they should be selected and tuned based on the app's threat model and risk tolerance.
 ---

--- a/knowledge/android/MASVS-RESILIENCE/MASTG-KNOW-0033.md
+++ b/knowledge/android/MASVS-RESILIENCE/MASTG-KNOW-0033.md
@@ -24,9 +24,9 @@ Android classes, methods, fields, packages, and local variables can be renamed t
 
 This is a type of layout obfuscation, which doesn't impact the program's performance.
 
-R8 and ProGuard can rename classes, methods, and fields during the release build process. The behavior is controlled through the release build configuration and keep rules that preserve selected identifiers. See the [Android app optimization documentation](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization), the [Android keep rules guide](https://developer.android.com/topic/performance/app-optimization/add-keep-rules), and the [ProGuard manual](https://www.guardsquare.com/manual/configuration/usage).
+R8 and @MASTG-TOOL-0022 can rename classes, methods, and fields during the release build process. The behavior is controlled through the release build configuration and keep rules that preserve selected identifiers. See the [Android app optimization documentation](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization), the [Android keep rules guide](https://developer.android.com/topic/performance/app-optimization/add-keep-rules), and the @MASTG-TOOL-0022 [manual](https://www.guardsquare.com/manual/configuration/usage).
 
-The following example shows how identifier renaming can be enabled in a release build with R8 or ProGuard.
+The following example shows how identifier renaming can be enabled in a release build with R8 or @MASTG-TOOL-0022.
 
 ```groovy
 android {
@@ -36,7 +36,7 @@ android {
             // your project's release build type.
             minifyEnabled true
 
-            // Includes the default ProGuard rules files that are packaged with
+            // Includes the default optimization rules files packaged with
             // the Android Gradle plugin. To learn more, go to the section about
             // R8 configuration files.
             proguardFiles(
@@ -48,7 +48,7 @@ android {
 }
 ```
 
-The file `proguard-rules.pro` is where you define custom ProGuard rules. With the flag `-keep` you can keep certain code that is not being removed by R8, which might otherwise produce errors. For example:
+The file `proguard-rules.pro` is where you define custom @MASTG-TOOL-0022 rules. With the flag `-keep` you can keep certain code that is not being removed by R8, which might otherwise produce errors. For example:
 
 ```pro
 -keep class com.example.api.PublicApi { *; }
@@ -65,9 +65,9 @@ String encryption replaces plaintext literals with encoded or encrypted represen
 
 When this technique is applied, the original string values may no longer appear directly in the decompiled code or extracted DEX data; the clear strings are only present at runtime.
 
-`dProtect` extends the ProGuard rule format with string obfuscation passes. See the [dProtect strings encryption documentation](https://obfuscator.re/dprotect/passes/strings/) for more information about how to encrypt strings.
+@MASTG-TOOL-0153 extends the @MASTG-TOOL-0022 rule format with string obfuscation passes. See its [strings encryption documentation](https://obfuscator.re/dprotect/passes/strings/) for more information about how to encrypt strings.
 
-The following example shows how string obfuscation can be configured with `dProtect`.
+The following example shows how string obfuscation can be configured with @MASTG-TOOL-0153.
 
 ```pro
 -obfuscate-strings class com.example.sensitive.ApiClient {
@@ -81,6 +81,17 @@ The following example shows how string obfuscation can be configured with `dProt
 Android apps can keep part of their logic outside the main static DEX view and make it available only at runtime. This can be done by loading additional code with class loaders such as `DexClassLoader`, `PathClassLoader`, or `InMemoryDexClassLoader` (see the [Android documentation](https://developer.android.com/reference/dalvik/system/package-summary)), or by storing code in a transformed representation and restoring it before execution.
 
 This changes where executable logic is stored and when it becomes available to the runtime. As a result, part of the application logic may be separated from the main static codebase and may only become visible after the corresponding loading or unpacking logic executes.
+
+For example, an app can store `payload.dex.enc` in `assets/`, decrypt it after startup, and load the resulting DEX bytes with `InMemoryDexClassLoader`.
+
+```kotlin
+val encrypted = assets.open("payload.dex.enc").readBytes()
+val dexBuffer = ByteBuffer.wrap(decrypt(encrypted, runtimeKey))
+val loader = InMemoryDexClassLoader(dexBuffer, classLoader)
+val entry = loader.loadClass("com.example.protected.Entry")
+```
+
+Use @MASTG-TOOL-0009 with @MASTG-TECH-0165 to identify known compilers, obfuscators, and packers in APKs. The absence of a known signature does not prove that dynamic loading or custom packing is not present.
 
 ### Reflection and Indirect Invocation
 
@@ -96,9 +107,9 @@ The control-flow graph of a function is a representation of the elementary compu
 
 Control flow obfuscation modifies the bytecode to produce a more complex control-flow graph in the decompiled output. Common examples include inserted conditions, opaque predicates, or transformations around branch instructions such as `GOTO #offset`.
 
-`dProtect` provides a dedicated pass for this transformation. See the [dProtect control-flow obfuscation documentation](https://obfuscator.re/dprotect/passes/control-flow/).
+@MASTG-TOOL-0153 provides a dedicated pass for this transformation. See its [control-flow obfuscation documentation](https://obfuscator.re/dprotect/passes/control-flow/).
 
-The following example shows how control-flow obfuscation can be configured with `dProtect`.
+The following example shows how control-flow obfuscation can be configured with @MASTG-TOOL-0153.
 
 ```pro
 -obfuscate-control-flow class com.example.sensitive.** { *; }
@@ -115,6 +126,16 @@ This technique is different from control flow obfuscation. Control flow obfuscat
 Obfuscation in Android apps is not limited to executable code. Apps can also encode or encrypt files stored in `assets/`, `res/raw/`, or other packaged resources so that their content is not directly visible after extracting the APK.
 
 These resources may contain configuration data, scripts, model files, web assets, or auxiliary data consumed by the Java or Kotlin layer at runtime. The app then includes logic to decode or decrypt the resource before using it.
+
+For example, an app can store `rules.json.enc` or `model.bin.enc` in `assets/` and decrypt the file with `javax.crypto.Cipher` before parsing or passing it to the relevant runtime component.
+
+```kotlin
+val encrypted = assets.open("rules.json.enc").readBytes()
+val cleartext = cipher.doFinal(encrypted)
+val rules = JSONObject(cleartext.decodeToString())
+```
+
+This protects against direct resource extraction from the APK, but it does not prevent recovery of the decrypted data or decryption material during runtime analysis.
 
 ## Native Layer
 
@@ -136,7 +157,7 @@ This makes the execution flow harder to follow because the natural branching str
 
 [O-MVLL](https://obfuscator.re/omvll/passes/control-flow-flattening/) provides a control-flow flattening pass for native code.
 
-The following example shows how control-flow flattening can be enabled with `O-MVLL`.
+The following example shows how control-flow flattening can be enabled with O-MVLL.
 
 ```python
 def flatten_cfg(self, mod: omvll.Module, func: omvll.Function):
@@ -153,7 +174,7 @@ In native code, one way to achieve this is to add duplicate basic blocks, redund
 
 For example, adding duplicate basic blocks is made by [O-MVLL Basic Block Duplicate](https://obfuscator.re/omvll/passes/basic-block-duplicate/), which, as said previously, duplicates the selected basic blocks and inserts a runtime branch that chooses between equivalent versions of the same logic.
 
-The following example shows how junk code can be introduced with `O-MVLL`'s Basic Block Duplicate pass.
+The following example shows how junk code can be introduced with O-MVLL's Basic Block Duplicate pass.
 
 ```python
 def basic_block_duplicate(self, mod: omvll.Module, func: omvll.Function):
@@ -166,7 +187,7 @@ Arithmetic obfuscation replaces simple arithmetic or bitwise operations with mor
 
 [O-MVLL](https://obfuscator.re/omvll/passes/arithmetic/) provides an arithmetic obfuscation pass that rewrites operations into more complex expressions.
 
-The following example shows how arithmetic obfuscation can be enabled with `O-MVLL`.
+The following example shows how arithmetic obfuscation can be enabled with O-MVLL.
 
 ```python
 def obfuscate_arithmetic(self, mod: omvll.Module,
@@ -182,7 +203,7 @@ Plaintext strings in native code can reveal implementation details such as file 
 
 [O-MVLL](https://obfuscator.re/omvll/passes/strings-encoding/) provides several string encoding options for native code.
 
-The following example shows how string encoding can be configured with `O-MVLL`.
+The following example shows how string encoding can be configured with O-MVLL.
 
 ```python
 def obfuscate_string(self, _, __, string: bytes):
@@ -197,7 +218,7 @@ Opaque constants protect integer constants by replacing them with more complex c
 
 [O-MVLL](https://obfuscator.re/omvll/passes/opaque-constants/) provides a pass for obfuscating constants in native code.
 
-The following example shows how opaque constants can be enabled with `O-MVLL`.
+The following example shows how opaque constants can be enabled with O-MVLL.
 
 ```python
 class Config(omvll.ObfuscationConfig):
@@ -213,7 +234,7 @@ Obfuscated function calls hide the original callee by replacing direct calls wit
 
 [O-MVLL](https://obfuscator.re/omvll/passes/indirect-call/) provides an indirect call pass that converts direct calls into indirect calls.
 
-The following example shows how indirect calls can be enabled with `O-MVLL`.
+The following example shows how indirect calls can be enabled with O-MVLL.
 
 ```python
 def indirect_call(self, mod: omvll.Module, func: omvll.Function):

--- a/knowledge/ios/MASVS-RESILIENCE/MASTG-KNOW-0089.md
+++ b/knowledge/ios/MASVS-RESILIENCE/MASTG-KNOW-0089.md
@@ -4,11 +4,42 @@ platform: ios
 title: Obfuscation
 ---
 
-@MASTG-KNOW-0111 introduces several well-known obfuscation techniques that can be used in mobile apps in general.
+@MASTG-KNOW-0111 introduces common obfuscation techniques that apply across platforms. On iOS, these techniques can affect native Mach-O code, Objective-C and Swift runtime metadata, bundled resources, and data used by the app.
 
-## Name Obfuscation
+iOS applications are distributed as signed app bundles containing a main Mach-O executable and, often, embedded frameworks, app extensions, and resource files.
 
-The standard compiler generates binary symbols based on class and function names from the source code. Therefore, if no obfuscation was applied, symbol names remain meaningful and can be easily read straight from the app binary. For instance, a function which detects a jailbreak can be located by searching for relevant keywords (e.g. "jailbreak"). The listing below shows the disassembled function `JailbreakDetectionViewController.jailbreakTest4Tapped` from the @MASTG-APP-0024.
+Unlike Android Java/Kotlin code, which is compiled to DEX bytecode and can often be decompiled back into Java-like code, iOS apps are compiled into native Mach-O binaries. Static analysis usually works from ARM64 machine code, Objective-C runtime metadata, Swift metadata, symbols, and strings. This means the original source structure, high-level control flow, local variable names, and many type details are not preserved in the same way, making iOS decompilation less direct than Android bytecode decompilation.
+
+This page describes common iOS obfuscation techniques and the binary artifacts they affect.
+
+Learn more about iOS obfuscation techniques:
+
+- [O-MVLL](https://obfuscator.re/omvll/) is an LLVM-based obfuscator for native code. Its documentation describes passes such as string encoding, control-flow flattening, opaque constants, indirect calls and branches, Objective-C metadata cleaning, and anti-hooking.
+- ["Protecting Million-User iOS Apps with Obfuscation: Motivations, Pitfalls, and Experience"](https://faculty.ist.psu.edu/wu/papers/obf-ii.pdf) describes practical iOS obfuscation at scale and discusses motivations, pitfalls, and lessons learned from deploying obfuscation in production apps.
+
+## Mach-O Binaries and Runtime Metadata
+
+Mach-O binaries can expose several categories of metadata during static analysis:
+
+- Exported symbols and local symbol table entries.
+- Objective-C class names, categories, protocols, properties, and selectors.
+- Swift type descriptors, protocol metadata, and mangled Swift symbols.
+- C and C++ symbols, including mangled C++ names.
+- String literals and constants stored in Mach-O sections such as `__TEXT.__cstring`.
+
+Release builds often strip debugging information and local symbols, but normal symbol stripping does not remove all runtime metadata. Objective-C and Swift features such as dynamic dispatch, reflection, Interface Builder references, and interoperability through `@objc` can require some names or descriptors to remain present in the binary.
+
+Swift and C++ name mangling is different from deliberate obfuscation. Name mangling encodes type and namespace information into a compiler-specific symbol format; demangling tools can recover readable names in many cases (see @MASTG-TECH-0114).
+
+### Symbol Stripping
+
+Symbol stripping removes symbol information from Mach-O binaries, including function names and other metadata that can make reverse engineering easier. It is a basic form of native code obfuscation, but it does not transform control flow, encode strings, or remove all runtime metadata required by Objective-C and Swift. This topic overlaps with debug-symbol handling, which is covered in more detail in @MASTG-KNOW-0063.
+
+### Identifier Renaming
+
+iOS classes, methods, functions, properties, selectors, Swift symbols, type descriptors, storyboard identifiers, and nib references can be renamed to make it harder to correlate an identifier with its purpose during static analysis.
+
+The standard compiler generates binary symbols based on class and function names from the source code. Therefore, if no obfuscation is applied, symbol names can remain meaningful and can be read from the app binary. For instance, a function which detects a jailbreak can be located by searching for relevant keywords such as `jailbreak`. The listing below shows the disassembled function `JailbreakDetectionViewController.jailbreakTest4Tapped` from @MASTG-APP-0024.
 
 ```assembly
 __T07DVIA_v232JailbreakDetectionViewControllerC20jailbreakTest4TappedyypF:
@@ -16,7 +47,7 @@ stp        x22, x21, [sp, #-0x30]!
 mov        rbp, rsp
 ```
 
-After the obfuscation we can observe that the symbol's name is no longer meaningful as shown on the listing below.
+After identifier renaming, the symbol name is no longer meaningful:
 
 ```assembly
 __T07DVIA_v232zNNtWKQptikYUBNBgfFVMjSkvRdhhnbyyFySbyypF:
@@ -24,31 +55,142 @@ stp        x22, x21, [sp, #-0x30]!
 mov        rbp, rsp
 ```
 
-Nevertheless, this only applies to the names of functions, classes and fields. The actual code remains unmodified, so an attacker can still read the disassembled version of the function and try to understand its purpose (e.g. to retrieve the logic of a security algorithm).
+This only applies to the names of functions, classes, and fields. The actual code remains unmodified, so the disassembled version of the function can still reveal the function's logic.
 
-## Instruction Substitution
+Runtime features can depend on stable names. Examples include `NSClassFromString`, key-value coding, reflection, `Codable` key mapping, dynamic selectors, `@objc` declarations, storyboard references, and nib loading. iOS obfuscators therefore commonly use keep rules, mapping files, or build-time project analysis to preserve names that the runtime or app resources still need.
 
-This technique replaces standard binary operators like addition or subtraction with more complex representations. For example an addition `x = a + b` can be represented as `x = -(-a) - (-b)`. However, using the same replacement representation could be easily reversed, so it is recommended to add multiple substitution techniques for a single case and introduce a random factor. This technique is vulnerable to deobfuscation, but depending on the complexity and depth of the substitutions, applying it can still be time consuming.
+@MASTG-TOOL-0068 is an example of source-level Swift name obfuscation. It analyzes an Xcode project and replaces selected Swift identifiers before compilation.
 
-## Control Flow Flattening
+### String Encryption
 
-Control flow flattening replaces original code with a more complex representation. The transformation breaks the body of a function into basic blocks and puts them all inside a single infinite loop with a switch statement that controls the program flow. This makes the program flow significantly harder to follow because it removes the natural conditional constructs that usually make the code easier to read.
+String literals can reveal implementation details that are relevant for reverse engineering and understanding the app's business logic, such as endpoint URLs, file paths, feature names, license strings, API keys, jailbreak or debugger detection artifacts, and error messages.
 
-<img src="Images/Chapters/0x06j/control-flow-flattening.png" width="600px">
+String encryption replaces plaintext literals with encoded or encrypted representations and adds runtime logic that reconstructs the original value before use. On iOS, string literals may appear in Mach-O sections, Swift metadata, Objective-C metadata, resource files, or generated code.
 
-The image shows how control flow flattening alters code. See ["Obfuscating C++ programs via control flow flattening"](https://web.archive.org/web/20240414202600/http://ac.inf.elte.hu/Vol_030_2009/003.pdf) for more information.
+When this technique is applied, the original string values may no longer appear directly in extracted strings or static Mach-O data; the clear strings are only present at runtime.
 
-## Dead Code Injection
+Some strings cannot be transformed without additional handling because platform frameworks or app resources reference them by name. Examples include Objective-C selectors, class names used by the runtime, storyboard identifiers, localization keys, and values consumed by external services.
 
-This technique makes the program's control flow more complex by injecting dead code into the program. Dead code is a stub of code that doesn't affect the original program's behaviour but increases the overhead for the reverse engineering process.
+O-MVLL provides several [string encoding options](https://obfuscator.re/omvll/passes/strings-encoding/) for native code.
 
-## String Encryption
+The following example shows how string encoding can be configured with O-MVLL.
 
-Applications are often compiled with hardcoded keys, licences, tokens and endpoint URLs. By default, all of them are stored in plaintext in the data section of an application's binary. This technique encrypts these values and injects stubs of code into the program that will decrypt that data before it is used by the program.
+```python
+def obfuscate_string(self, _, __, string: bytes):
+    if string == b"https://api.example.com":
+        return omvll.StringEncOptLocal()
+    return False
+```
 
-## Recommended Tools
+### Control Flow Obfuscation
 
-- @MASTG-TOOL-0068 can be used to perform name obfuscation. It reads the source code of the Xcode project and replaces all names of classes, methods and fields with random values before the compiler is used.
-- [obfuscator-llvm](https://github.com/obfuscator-llvm) operates on the Intermediate Representation (IR) instead of the source code. It can be used for symbol obfuscation, string encryption and control flow flattening. Since it's based on IR, it can hide out significantly more information about the application as compared to SwiftShield.
+The control-flow graph of a function represents the basic blocks and the conditions required to reach them. This representation is usually an early step in native code analysis and decompilation.
 
-Learn more about iOS obfuscation techniques in the paper ["Protecting Million-User iOS Apps with Obfuscation: Motivations, Pitfalls, and Experience"](https://faculty.ist.psu.edu/wu/papers/obf-ii.pdf "Paper - Protecting Million-User iOS Apps with Obfuscation: Motivations, Pitfalls, and Experience").
+Control-flow obfuscation modifies the compiled representation of functions to produce a more complex control-flow graph in the disassembled or decompiled output. Common examples include control-flow flattening, opaque predicates, and transformations around branch instructions.
+
+Control-flow flattening replaces original code with a more complex representation. The transformation breaks the body of a function into basic blocks and places them inside a dispatcher, commonly an infinite loop with a switch statement that controls the program flow. This removes the natural conditional constructs that usually make code easier to read.
+
+<img src="Images/Chapters/0x06j/control-flow-flattening.png" width="600px" />
+
+The image shows how control-flow flattening alters code. See ["Obfuscating C++ programs via control flow flattening"](https://web.archive.org/web/20240414202600/http://ac.inf.elte.hu/Vol_030_2009/003.pdf) for more information.
+
+O-MVLL provides [control-flow flattening](https://obfuscator.re/omvll/passes/control-flow-flattening/) and [control-flow breaking](https://obfuscator.re/omvll/passes/control-flow-breaking/) passes for native code. Its control-flow breaking pass documents iOS Swift limitations and should be restricted to user-defined functions.
+
+The following example shows how control-flow flattening can be enabled with O-MVLL.
+
+```python
+def flatten_cfg(self, mod: omvll.Module, func: omvll.Function):
+    if func.name == "validate_license":
+        return True
+    return False
+```
+
+### Instruction and Arithmetic Obfuscation
+
+Instruction substitution replaces standard operations with more complex representations. For example, an addition such as `x = a + b` can be represented as `x = -(-a) - (-b)`. Using a single replacement pattern repeatedly can make the transformation easier to identify, so implementations commonly use several substitution patterns and introduce randomness. Depending on the complexity and depth of the substitutions, reversing the transformed code can still be time consuming.
+
+Arithmetic obfuscation replaces simple arithmetic or bitwise operations with more complex equivalent expressions. O-MVLL provides an [arithmetic obfuscation pass](https://obfuscator.re/omvll/passes/arithmetic/) that rewrites operations into more complex expressions.
+
+The following example shows how arithmetic obfuscation can be enabled with O-MVLL.
+
+```python
+def obfuscate_arithmetic(self, mod: omvll.Module,
+                         func: omvll.Function) -> omvll.ArithmeticOpt:
+    if func.name == "compute_token":
+        return omvll.ArithmeticOpt(rounds=8)
+    return False
+```
+
+### Opaque Constants
+
+Opaque constants protect integer constants by replacing them with more complex computations that reconstruct the original value at runtime. This makes well-known values, magic numbers, and algorithm-specific constants less obvious during static analysis.
+
+O-MVLL provides an [opaque constants pass](https://obfuscator.re/omvll/passes/opaque-constants/) for native code.
+
+The following example shows how opaque constants can be enabled with O-MVLL.
+
+```python
+class Config(omvll.ObfuscationConfig):
+    def obfuscate_constants(self, mod: omvll.Module, func: omvll.Function):
+        if "initialize_keys" in func.demangled_name:
+            return True
+        return False
+```
+
+### Dead Code and Junk Code
+
+Dead code injection makes the program's control flow more complex by adding code that does not affect the original program behavior. These extra blocks increase the amount of code that must be inspected during reverse engineering.
+
+Junk code has a similar goal: add noisy or annoying code paths without changing the intended behavior of the original function. O-MVLL's [Basic Block Duplicate](https://obfuscator.re/omvll/passes/basic-block-duplicate/) pass is an example of this type of transformation.
+
+The following example shows how junk code can be introduced with O-MVLL's Basic Block Duplicate pass.
+
+```python
+def basic_block_duplicate(self, mod: omvll.Module, func: omvll.Function):
+    return omvll.BasicBlockDuplicateWithProbability(20)
+```
+
+### Obfuscated Function Calls
+
+Obfuscated function calls hide the original callee by replacing direct calls with indirect or reconstructed calls. This makes the call graph harder to recover because static analysis tools can no longer follow all call edges directly from the disassembly.
+
+O-MVLL provides passes for [indirect calls](https://obfuscator.re/omvll/passes/indirect-call/) and [indirect branches](https://obfuscator.re/omvll/passes/indirect-branch/). Its indirect branch pass documents known limitations for iOS apps built in Release mode, so the transformation should be validated on the target build configuration.
+
+The following example shows how indirect calls can be enabled with O-MVLL.
+
+```python
+def indirect_call(self, mod: omvll.Module, func: omvll.Function):
+    if func.name == "perform_check":
+        return True
+    return False
+```
+
+### Objective-C Metadata Cleaning
+
+Objective-C runtime metadata can expose class names, method names, selectors, and protocol information. Cleaning or transforming this metadata can reduce the amount of semantic information visible in the binary, but Objective-C runtime behavior depends on some of this information remaining consistent.
+
+O-MVLL documents an [Objective-C Cleaner](https://obfuscator.re/omvll/passes/objcleaner/) pass, but its current documentation marks it as work in progress. Production tooling must still preserve metadata required by Objective-C runtime behavior and app resources.
+
+### Packing and Runtime Unpacking
+
+Packing stores code or data in a compressed or encrypted representation and restores it at runtime. On iOS, code signing and platform memory protections constrain arbitrary self-modifying code and runtime code generation. App shielding products therefore typically apply transformations before signing, use signed native loaders, or focus on runtime decoding of data and control-flow assets.
+
+@MASTG-KNOW-0111 describes packing at a generic level. On iOS, a practical pattern is to avoid unsigned runtime-generated code and instead ship a signed loader, interpreter, or state machine together with encrypted data. For example, an app can include `policy.vm.enc` or `rules.bundle.enc` in the app bundle; the signed loader decrypts the blob after startup and interprets the resulting bytecode or state table in memory. Static extraction of the IPA then reveals only the encrypted blob and the loader, while dynamic analysis after decryption can still recover the plaintext representation.
+
+### Resource and Asset Encryption
+
+Obfuscation in iOS apps is not limited to executable code. Apps can also encode or encrypt files stored in the app bundle, such as configuration files, scripts, web assets, model files, or other auxiliary data. The app then includes logic to decode or decrypt the resource before using it.
+
+For example, an app can store `security-rules.json.enc`, `model.bin.enc`, or `index.html.enc` in the app bundle and decrypt the file with CryptoKit or CommonCrypto before parsing or rendering it. See @MASTG-KNOW-0066 and @MASTG-KNOW-0067 for iOS cryptographic API context.
+
+```swift
+let url = Bundle.main.url(
+    forResource: "security-rules",
+    withExtension: "json.enc"
+)!
+let encrypted = try Data(contentsOf: url)
+let cleartext = try decrypt(encrypted, with: runtimeKey)
+let rules = try JSONDecoder().decode(SecurityRules.self, from: cleartext)
+```
+
+This protects against direct resource extraction from the IPA, but it does not prevent recovery of the decrypted data or decryption material during runtime analysis.

--- a/tests-beta/ios/MASVS-RESILIENCE/MASTG-TEST-0391.md
+++ b/tests-beta/ios/MASVS-RESILIENCE/MASTG-TEST-0391.md
@@ -1,7 +1,7 @@
 ---
 platform: ios
 title: Insufficient Obfuscation of Security-Relevant Native Code
-id: MASTG-TEST-0x93
+id: MASTG-TEST-0391
 type: [static, package, manual]
 weakness: MASWE-0089
 best-practices: [MASTG-BEST-0029]

--- a/tests-beta/ios/MASVS-RESILIENCE/MASTG-TEST-0x93.md
+++ b/tests-beta/ios/MASVS-RESILIENCE/MASTG-TEST-0x93.md
@@ -1,0 +1,50 @@
+---
+platform: ios
+title: Insufficient Obfuscation of Security-Relevant Native Code
+id: MASTG-TEST-0x93
+type: [static, package, manual]
+weakness: MASWE-0089
+best-practices: [MASTG-BEST-0029]
+profiles: [R]
+knowledge: [MASTG-KNOW-0089]
+---
+
+## Overview
+
+If native Mach-O code that implements security-relevant logic is not obfuscated, reverse engineering of packaged iOS binaries can expose business logic, device attestation and environment checks, integrity checks, and other implementation details that help an attacker understand the app and model attacks.
+
+This test checks whether the obfuscation techniques applied to the main executable and bundled Mach-O binaries prevent straightforward identification, correlation, and reverse engineering of security-relevant logic through strings, constants, symbols, runtime metadata, call structure, or control flow.
+
+Refer to @MASTG-KNOW-0089 for common iOS obfuscation mechanisms and indicators to look for.
+
+**Example Attack Scenario:**
+
+Suppose a banking app moves its integrity and jailbreak checks into Swift, Objective-C, or C/C++ code compiled into Mach-O binaries, assuming native code is inherently harder to analyze, but does not apply any obfuscation.
+
+1. An attacker extracts the app package and identifies the main executable and bundled frameworks.
+2. Plaintext strings, Objective-C selectors, or Swift symbols immediately reveal every file path, URL, and runtime artifact the app checks, requiring little further analysis to identify the protection's scope.
+3. The function names, runtime metadata, and call structure fully expose the check's logic; the attacker understands it within minutes.
+4. The attacker patches a branch or hooks the function at runtime on a jailbroken device to return a benign result, bypasses the integrity check, and accesses features or data that should have been blocked.
+
+## Steps
+
+1. Use @MASTG-TECH-0058 to extract the relevant binaries from the app package.
+
+## Observation
+
+The output should contain the extracted Mach-O binaries, such as the main executable, bundled frameworks, app extensions, or dynamic libraries.
+
+## Evaluation
+
+The test case fails if the app's Mach-O binaries allow an attacker to identify, correlate, and reverse engineer security-relevant logic with reasonable effort.
+
+**Further Validation Required:**
+
+Use @MASTG-TECH-0066 to inspect the app binaries and @MASTG-TECH-0076 to review the disassembled code. Use @MASTG-TECH-0071 to retrieve strings and @MASTG-TECH-0114 to demangle Swift or C++ symbols when needed. Refer to @MASTG-KNOW-0089 to determine whether the code shows indicators of obfuscation:
+
+- Determine whether native strings, constants, selectors, or metadata (e.g., monitored file paths, API tokens, or integrity check values) are in plaintext.
+- Determine whether Objective-C metadata, Swift or C++ symbols, exported symbols, or bundled framework names retain descriptive identifiers that can be directly correlated with security-relevant functionality.
+- Determine whether the disassembled function structure and call edges still reveal the original security-relevant logic with recognizable patterns.
+- Determine whether protected code or data is encrypted, packed, transformed, or decoded only at runtime.
+
+Correlate the findings and determine whether the obfuscation applied to the iOS native layer still allows security-relevant logic to be identified and reverse engineered with reasonable effort.

--- a/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0093.md
+++ b/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0093.md
@@ -9,7 +9,7 @@ masvs_v1_levels:
 - R
 profiles: [R]
 status: deprecated
-covered_by: [MASTG-TEST-0x93]
+covered_by: [MASTG-TEST-0391]
 deprecation_note: New version available in MASTG V2
 ---
 

--- a/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0093.md
+++ b/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0093.md
@@ -8,6 +8,9 @@ title: Testing Obfuscation
 masvs_v1_levels:
 - R
 profiles: [R]
+status: deprecated
+covered_by: [MASTG-TEST-0x93]
+deprecation_note: New version available in MASTG V2
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary
- Port MASTG-TEST-0093 to a v2 iOS test for insufficient obfuscation of security-relevant native code.
- Expand iOS obfuscation knowledge and align Android obfuscation knowledge examples/tool references.
- Deprecate the legacy iOS v1 test and link the iOS obfuscation knowledge to the resilience best practice metadata.

Closes #3007