### PR TITLE
fix duplicate

### DIFF
--- a/tests-beta/android/MASVS-CODE/MASTG-TEST-0392.md
+++ b/tests-beta/android/MASVS-CODE/MASTG-TEST-0392.md
@@ -1,7 +1,7 @@
 ---
 platform: android
 title: References to Enforced Updating APIs
-id: MASTG-TEST-0381
+id: MASTG-TEST-0392
 type: [static, code, manual]
 weakness: MASWE-0075
 profiles: [L2]

--- a/tests/android/MASVS-CODE/MASTG-TEST-0036.md
+++ b/tests/android/MASVS-CODE/MASTG-TEST-0036.md
@@ -9,7 +9,7 @@ masvs_v1_levels:
 - L2
 profiles: [L2]
 status: deprecated
-covered_by: ['MASTG-TEST-0381', 'MASTG-TEST-0382']
+covered_by: ['MASTG-TEST-0392', 'MASTG-TEST-0382']
 deprecation_note: New version available in MASTG V2
 ---
 


### PR DESCRIPTION
MASTG-TEST-0381 existed in both:

- tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0381.md — PendingIntent (added first, kept as-is)
- tests-beta/android/MASVS-CODE/MASTG-TEST-0381.md — Enforced Updating (added later, renamed)

Changes made:

- Renamed tests-beta/android/MASVS-CODE/MASTG-TEST-0381.md → tests-beta/android/MASVS-CODE/MASTG-TEST-0392.md (via git mv)
- Updated id: field inside that file from MASTG-TEST-0381 → MASTG-TEST-0392
- Updated covered_by in tests/android/MASVS-CODE/MASTG-TEST-0036.md from MASTG-TEST-0381 → MASTG-TEST-0392