### PR TITLE
Deprecate TEST-0051

### DIFF
--- a/tests/android/MASVS-RESILIENCE/MASTG-TEST-0051.md
+++ b/tests/android/MASVS-RESILIENCE/MASTG-TEST-0051.md
@@ -10,6 +10,7 @@ masvs_v1_levels:
 profiles: [R]
 covered_by: [MASTG-TEST-0368, MASTG-TEST-0369]
 deprecation_note: New version available in MASTG V2
+status: deprecated
 ---
 
 ## Overview


### PR DESCRIPTION
Already migrated but `status: deprecated` was forgotten
