### PR TITLE
Deprecate MASTG-TEST-0026 with new version info

### DIFF
--- a/tests/android/MASVS-CODE/MASTG-TEST-0026.md
+++ b/tests/android/MASVS-CODE/MASTG-TEST-0026.md
@@ -9,6 +9,9 @@ masvs_v1_levels:
 - L1
 - L2
 profiles: [L1, L2]
+status: deprecated
+covered_by: [MASTG-0372, MASTG-0373, MASTG-0374, MASTG-0375]
+deprecation_note: New version available in MASTG V2
 ---
 
 ## Overview


### PR DESCRIPTION
Mark MASTG-TEST-0026 as deprecated and add notes.
