### PR TITLE
Fix fake IDs instructions

### DIFF
--- a/.github/instructions/mastg-apps.instructions.md
+++ b/.github/instructions/mastg-apps.instructions.md
@@ -16,7 +16,7 @@ Standards for authoring reference application pages under `apps/`. These pages d
 - The filename defines the app ID: `MASTG-APP-\d{4}.md`
 - Do not add an `id:` field to the YAML front matter
 
-When creating a new app (whether during porting or writing from scratch), use a **fake ID** with the notation `MASTG-APP-0x##` (for example, `MASTG-APP-0x33`). This prevents conflicts between parallel pull requests. Create new fake IDs incrementally (e.g., `MASTG-APP-0x33`, `MASTG-APP-0x34`, `MASTG-APP-0x35`) as you add new content.
+When creating a new app (whether during porting or writing from scratch), use a **fake ID** starting at `MASTG-APP-0x01` and incrementing within the PR (e.g., `MASTG-APP-0x01`, `MASTG-APP-0x02`, `MASTG-APP-0x03`). This prevents conflicts between parallel pull requests.
 
 Once your pull request is reviewed and ready to merge, the team will assign real IDs (for example, `MASTG-APP-0008`) before the content is published.
 

--- a/.github/instructions/mastg-best-practice.instructions.md
+++ b/.github/instructions/mastg-best-practice.instructions.md
@@ -10,7 +10,7 @@ Best practices live under `best-practices/` and each file name must be the best-
 
 ## Creating Best Practice IDs
 
-When creating a new best practice (whether during porting or writing from scratch), use a **fake ID** with the notation `MASTG-BEST-0x##` (for example, `MASTG-BEST-0x33`). This prevents conflicts between parallel pull requests. Create new fake IDs incrementally (e.g., `MASTG-BEST-0x33`, `MASTG-BEST-0x34`, `MASTG-BEST-0x35`) as you add new content.
+When creating a new best practice (whether during porting or writing from scratch), use a **fake ID** starting at `MASTG-BEST-0x01` and incrementing within the PR (e.g., `MASTG-BEST-0x01`, `MASTG-BEST-0x02`, `MASTG-BEST-0x03`). This prevents conflicts between parallel pull requests.
 
 Once your pull request is reviewed and ready to merge, the team will assign real IDs (for example, `MASTG-BEST-0025`) before the content is published.
 

--- a/.github/instructions/mastg-demo.instructions.md
+++ b/.github/instructions/mastg-demo.instructions.md
@@ -133,7 +133,7 @@ The build system (`.github/workflows/build-ios-demos.yml`) processes the followi
 
 ## Creating Demo IDs
 
-When creating a new demo (whether porting from v1 or writing from scratch), use a **fake ID** with the notation `MASTG-DEMO-0x##` (for example, `MASTG-DEMO-0x33`). This prevents conflicts between parallel pull requests. Create new fake IDs incrementally (e.g., `MASTG-DEMO-0x33`, `MASTG-DEMO-0x34`, `MASTG-DEMO-0x35`) as you add new content.
+When creating a new demo (whether porting from v1 or writing from scratch), use a **fake ID** starting at `MASTG-DEMO-0x01` and incrementing within the PR (e.g., `MASTG-DEMO-0x01`, `MASTG-DEMO-0x02`, `MASTG-DEMO-0x03`). This prevents conflicts between parallel pull requests.
 
 Once your pull request is reviewed and ready to merge, the team will assign real IDs (for example, `MASTG-DEMO-0054`) before the content is published.
 

--- a/.github/instructions/mastg-knowledge.instructions.md
+++ b/.github/instructions/mastg-knowledge.instructions.md
@@ -34,7 +34,7 @@ File naming and IDs:
 - Do not add an `id:` field to the YAML front matter.
 - Place the file in the platform (`android` or `ios`) and MASVS category folder that best matches the subject.
 
-When creating a new knowledge page (whether during porting or writing from scratch), use a **fake ID** with the notation `MASTG-KNOW-0x##` (for example, `MASTG-KNOW-0x33`). This prevents conflicts between parallel pull requests. Create new fake IDs incrementally (e.g., `MASTG-KNOW-0x33`, `MASTG-KNOW-0x34`, `MASTG-KNOW-0x35`) as you add new content.
+When creating a new knowledge page (whether during porting or writing from scratch), use a **fake ID** starting at `MASTG-KNOW-0x01` and incrementing within the PR (e.g., `MASTG-KNOW-0x01`, `MASTG-KNOW-0x02`, `MASTG-KNOW-0x03`). This prevents conflicts between parallel pull requests.
 
 Once your pull request is reviewed and ready to merge, the team will assign real IDs (for example, `MASTG-KNOW-0112`) before the content is published.
 

--- a/.github/instructions/mastg-techniques.instructions.md
+++ b/.github/instructions/mastg-techniques.instructions.md
@@ -17,7 +17,7 @@ File naming and IDs:
 - The filename defines the technique ID: `MASTG-TECH-\d{4}.md`.
 - Do not add an `id:` field to the YAML front matter for techniques.
 
-When creating a new technique (whether during porting or writing from scratch), use a **fake ID** with the notation `MASTG-TECH-0x##` (for example, `MASTG-TECH-0x33`). This prevents conflicts between parallel pull requests. Create new fake IDs incrementally (e.g., `MASTG-TECH-0x33`, `MASTG-TECH-0x34`, `MASTG-TECH-0x35`) as you add new content.
+When creating a new technique (whether during porting or writing from scratch), use a **fake ID** starting at `MASTG-TECH-0x01` and incrementing within the PR (e.g., `MASTG-TECH-0x01`, `MASTG-TECH-0x02`, `MASTG-TECH-0x03`). This prevents conflicts between parallel pull requests.
 
 Once your pull request is reviewed and ready to merge, the team will assign real IDs (for example, `MASTG-TECH-0018`) before the content is published.
 

--- a/.github/instructions/mastg-test.instructions.md
+++ b/.github/instructions/mastg-test.instructions.md
@@ -55,7 +55,7 @@ Each test has two parts: the [Markdown metadata](#markdown-metadata) (YAML `fron
 
 ## Creating Test IDs
 
-When creating a new test (whether porting from v1 or writing from scratch), use a **fake ID** with the notation `MASTG-TEST-0x##` (for example, `MASTG-TEST-0x33`). This prevents conflicts between parallel pull requests. Create new fake IDs incrementally (e.g., `MASTG-TEST-0x33`, `MASTG-TEST-0x34`, `MASTG-TEST-0x35`) as you add new content.
+When creating a new test (whether porting from v1 or writing from scratch), use a **fake ID** starting at `MASTG-TEST-0x01` and incrementing within the PR (e.g., `MASTG-TEST-0x01`, `MASTG-TEST-0x02`, `MASTG-TEST-0x03`). This prevents conflicts between parallel pull requests.
 
 Once your pull request is reviewed and ready to merge, the team will assign real IDs (for example, `MASTG-TEST-0233`) before the content is published.
 

--- a/.github/instructions/mastg-tools.instructions.md
+++ b/.github/instructions/mastg-tools.instructions.md
@@ -18,7 +18,7 @@ Standards for authoring tool reference pages under `tools/`. These pages documen
 - The tool ID is defined by the filename: `MASTG-TOOL-\d{4}.md`
 - Do not add an `id:` field to the YAML front matter
 
-When creating a new tool (whether during porting or writing from scratch), use a **fake ID** with the notation `MASTG-TOOL-0x##` (for example, `MASTG-TOOL-0x33`). This prevents conflicts between parallel pull requests. Create new fake IDs incrementally (e.g., `MASTG-TOOL-0x33`, `MASTG-TOOL-0x34`, `MASTG-TOOL-0x35`) as you add new content.
+When creating a new tool (whether during porting or writing from scratch), use a **fake ID** starting at `MASTG-TOOL-0x01` and incrementing within the PR (e.g., `MASTG-TOOL-0x01`, `MASTG-TOOL-0x02`, `MASTG-TOOL-0x03`). This prevents conflicts between parallel pull requests.
 
 Once your pull request is reviewed and ready to merge, the team will assign real IDs (for example, `MASTG-TOOL-0051`) before the content is published.
 

--- a/.github/instructions/porting-mastg-v1-tests-to-v2.instructions.md
+++ b/.github/instructions/porting-mastg-v1-tests-to-v2.instructions.md
@@ -39,11 +39,11 @@ Also, review these. We'll be using them and creating new ones as well:
 
 **About the IDs:**
 
-- Use "fake IDs" with the `MASTG-TEST-0x` notation (for example, `MASTG-TEST-0x33`).
-- If a test must be split, suffix with a short decimal part during drafting (for example, `MASTG-TEST-0x33-1`, `MASTG-TEST-0x33-2`).
+- Use "fake IDs" starting at `0x01` and incrementing within the PR (for example, `MASTG-TEST-0x01`, `MASTG-TEST-0x02`).
+- If a test must be split, suffix with a short decimal part during drafting (for example, `MASTG-TEST-0x01-1`, `MASTG-TEST-0x01-2`).
 - Once the test is ready, the team will assign a real ID (for example, `MASTG-TEST-0233`).
 
-Use the same approach for demos (for example, `MASTG-DEMO-0x33-1`), best practices (for example, `MASTG-BEST-0x33`), knowledge (for example, `MASTG-KNOW-0x33`) and techniques (for example, `MASTG-TECH-0x33`) or any other content type. This way, we can keep track of the relationships between the content pieces during drafting and porting and avoid conflicts. Once the content is ready, we will assign real IDs.
+Use the same approach for demos (for example, `MASTG-DEMO-0x01`, `MASTG-DEMO-0x02`), best practices (for example, `MASTG-BEST-0x01`), knowledge (for example, `MASTG-KNOW-0x01`) and techniques (for example, `MASTG-TECH-0x01`, `MASTG-TECH-0x02`) or any other content type. Each content type has its own counter starting at `0x01` within the PR. This way, we can keep track of the relationships between the content pieces during drafting and porting and avoid conflicts. Once the content is ready, we will assign real IDs.
 
 **Language**: use simple language, be concise and clear
 


### PR DESCRIPTION
All fake IDs must start at 0x01 and increment (0x01, 0x02, 0x03) within the PR.