### PR TITLE
fix: generalize MASTG-TEST-0375 to cover explicit intents

### DIFF
--- a/tests-beta/android/MASVS-CODE/MASTG-TEST-0375.md
+++ b/tests-beta/android/MASVS-CODE/MASTG-TEST-0375.md
@@ -1,5 +1,5 @@
 ---
-title: Missing Validation of Data Returned from Implicit Intents
+title: Missing Validation of Data Returned from Inter-App Intent Results
 platform: android
 id: MASTG-TEST-0375
 type: [dynamic, hooks, manual]
@@ -11,25 +11,27 @@ profiles: [L1, L2]
 
 ## Overview
 
-An [implicit intent](https://developer.android.com/guide/components/intents-filters) is an `Intent` that does not name a concrete target component. Instead, it declares an action, and optionally data or categories, and Android resolves it to an installed component with a matching `<intent-filter>`. See @MASTG-KNOW-0025 for background on explicit and implicit intents and intent resolution.
+Apps commonly use the activity result APIs to request data from another app — for example, selecting a file, opening a document, or importing content. This applies to both **implicit intents** (where Android resolves the target from installed components matching an `<intent-filter>`) and **explicit intents** that target a specific external app by package name or component (for example, a dedicated "Attach file from Dropbox" button that hardcodes the Dropbox package). See @MASTG-KNOW-0025 for background on explicit and implicit intents and intent resolution.
 
-Apps commonly use implicit intents and activity result APIs to request data from another app, such as selecting a file, opening a document, or importing content. The selected responder controls the result returned to the caller, including values such as `Intent.getData()`, `ClipData`, extras, and provider metadata returned through `ContentResolver` queries, such as `OpenableColumns.DISPLAY_NAME`.
+In both cases, the **responding app fully controls the result** returned to the caller, including values such as `Intent.getData()`, `ClipData`, extras, and provider metadata returned through `ContentResolver` queries such as `OpenableColumns.DISPLAY_NAME`. The fact that an explicit intent was used does not make the responding app inherently trusted — a legitimate app can still return malformed, unexpected, or malicious data, and a compromised or malicious app installed under the targeted package name can return arbitrary values.
 
-The issue appears when the app treats the returned data as trusted. A responder can return unexpected URI schemes, provider-controlled metadata, filenames with path separators, or values that influence app behavior. If the caller uses those values without validation, they can affect file handling, content parsing, storage, navigation, backend requests, authorization decisions, account selection, transaction flows, or other security-relevant logic.
+The issue appears when the caller treats the returned data as trusted without validation. A responder can return unexpected URI schemes, provider-controlled metadata, filenames with path separators, or values that influence app behavior. If the caller uses those values without validation, they can affect file handling, content parsing, storage, navigation, backend requests, authorization decisions, account selection, transaction flows, or other security-relevant logic.
 
-This test dynamically checks whether data returned from an implicit intent result reaches security-relevant operations without validation or sanitization. Relevant API calls include the APIs used to launch the request (`startActivityForResult`, `ActivityResultLauncher.launch`), receive the result (`onActivityResult`, `ActivityResultCallback.onActivityResult`), read returned data (`Intent.getData`, `Intent.getClipData`, `Intent.getExtras`, `ContentResolver.query`, `ContentResolver.openInputStream`), and process the returned values in security-relevant code.
+This test dynamically checks whether data returned from any inter-app intent result — implicit or explicit — reaches security-relevant operations without validation or sanitization. Relevant API calls include the APIs used to launch the request (`startActivityForResult`, `ActivityResultLauncher.launch`), receive the result (`onActivityResult`, `ActivityResultCallback.onActivityResult`), read returned data (`Intent.getData`, `Intent.getClipData`, `Intent.getExtras`, `ContentResolver.query`, `ContentResolver.openInputStream`), and process the returned values in security-relevant code.
 
 ## Steps
 
 1. Use @MASTG-TECH-0005 to install the app.
 2. Use @MASTG-TECH-0043 to hook the relevant API calls.
-3. Exercise the app extensively to trigger flows that request data from another app through an implicit intent.
+3. Exercise the app extensively to trigger flows that request data from another app through an intent result. Cover both:
+    - **Implicit intent flows**: file pickers, document selectors, share sheets, or any flow where Android presents a chooser.
+    - **Explicit intent flows**: dedicated integrations that target a specific external app by package name or component (for example, "Attach from Dropbox", "Import from Drive", or any similar feature that names the external app).
 
 ## Observation
 
 The output should contain runtime traces of intent result handling flows. The output should include, when available:
 
-- The request intent details, such as action, data, type, categories, extras, and launch API.
+- The request intent details, such as action, data, type, categories, extras, target package or component (if explicit), and launch API.
 - The result callback or handler, such as `onActivityResult` or `ActivityResultCallback.onActivityResult`.
 - Returned data read by the app, such as `Intent.getData()`, `ClipData`, extras, or `ContentProvider` metadata.
 - APIs used to read returned data, such as `ContentResolver.query` or `ContentResolver.openInputStream`.
@@ -37,13 +39,13 @@ The output should contain runtime traces of intent result handling flows. The ou
 
 ## Evaluation
 
-The test case fails if data returned from an external intent result reaches a security-relevant operation without validation or sanitization.
+The test case fails if data returned from an external intent result — whether the originating intent was implicit or explicit — reaches a security-relevant operation without validation or sanitization.
 
 **Further Validation Required:**
 
 Using the hook backtraces, inspect each reported code location using @MASTG-TECH-0023:
 
 - Check whether the returned data comes from `Intent.getData()`, `ClipData`, extras, or `ContentProvider` metadata.
-- Check whether the returned data is controlled by an external responder.
+- Check whether the returned data is controlled by an external responder (regardless of whether the intent that triggered the flow was implicit or explicit).
 - Check whether the returned data affects file handling, content parsing, storage, navigation, backend requests, authorization decisions, account selection, transaction flows, or other security-relevant logic.
 - Check whether the app validates the returned data before use.


### PR DESCRIPTION
This PR closes #3906

## Description

`MASTG-TEST-0375` was scoped only to implicit intents, but the same trust issue exists with explicit intents targeting external apps. If an app has a dedicated "Attach from Dropbox" button that uses an explicit intent, the data Dropbox returns is still fully controlled by Dropbox — the app should not treat it as trusted without validation.

Changes made to `tests-beta/android/MASVS-CODE/MASTG-TEST-0375.md`:
- Renamed title from "Missing Validation of Data Returned from Implicit Intents" to "Missing Validation of Data Returned from Inter-App Intent Results"
- Expanded Overview to cover both implicit and explicit intents, with the Dropbox example from the issue
- Updated Steps to instruct testers to cover both implicit flows (file pickers, choosers) and explicit flows (named external app integrations)
- Updated Observation to capture target package/component when the intent is explicit
- Updated Evaluation to make clear the test applies regardless of intent type

## AI Tool Disclosure

- [x] This contribution includes AI-generated content.

**AI tools used:** Claude  
**Models and versions:** Claude Sonnet 4.6  
**Prompt summary:** Analyzed issue #3906 and the existing MASTG-TEST-0375 file, then generalized the title, overview, steps, observation, and evaluation sections to cover both implicit and explicit inter-app intents while preserving the existing style and all cross-references.  
**Mobile security expertise level:** medium  

## Contributor Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I followed the project style guide.
- [x] I validated the technical correctness of my changes and understand the topic.
- [x] This PR adds clear value and is not spam or low-effort content.