### PR TITLE
MASTG-TEST-0212: Clarify test case for hardcoded cryptographic keys

### DIFF
--- a/tests-beta/android/MASVS-CRYPTO/MASTG-TEST-0212.md
+++ b/tests-beta/android/MASVS-CRYPTO/MASTG-TEST-0212.md
@@ -17,7 +17,7 @@ The use of a key-related API or class, such as [`SecretKeySpec`](https://develop
 ## Steps
 
 1. Use @MASTG-TECH-0013 to reverse engineer the app.
-2. Use @MASTG-TECH-0014 to identify cryptographic key construction, import, derivation, or use, and trace the corresponding key material back to its source.
+2. Use @MASTG-TECH-0014 to look for the relevant APIs.
 
 ## Observation
 

--- a/tests-beta/android/MASVS-CRYPTO/MASTG-TEST-0212.md
+++ b/tests-beta/android/MASVS-CRYPTO/MASTG-TEST-0212.md
@@ -12,7 +12,7 @@ knowledge: [MASTG-KNOW-0012]
 
 In this test case, we will look for the use of hardcoded cryptographic keys in Android applications. Hardcoded key material may be passed to different cryptographic APIs or represented using different key classes and specifications. For example, the Java Cryptography Architecture (JCA) provides several [`KeySpec`](https://developer.android.com/reference/java/security/spec/KeySpec) implementations and key factory APIs for constructing cryptographic keys from supplied key material.
 
-The use of a key-related API or class, such as [`SecretKeySpec`](https://developer.android.com/reference/javax/crypto/spec/SecretKeySpec), does not by itself indicate that a key is hardcoded. The source of the key material must be traced to determine whether it is embedded in the application code.
+Cryptographic key material can be represented or imported through different APIs, including [`SecretKeySpec`](https://developer.android.com/reference/javax/crypto/spec/SecretKeySpec), algorithm-specific [`KeySpec`](https://developer.android.com/reference/java/security/spec/KeySpec) implementations, [`PKCS8EncodedKeySpec`](https://developer.android.com/reference/java/security/spec/PKCS8EncodedKeySpec), [`KeyFactory`](https://developer.android.com/reference/java/security/KeyFactory), and [`SecretKeyFactory`](https://developer.android.com/reference/javax/crypto/SecretKeyFactory). The use of any of these APIs does not by itself indicate that a key is hardcoded. The source of secret or private key material must be traced to determine whether it is embedded in the application code.
 
 ## Steps
 

--- a/tests-beta/android/MASVS-CRYPTO/MASTG-TEST-0212.md
+++ b/tests-beta/android/MASVS-CRYPTO/MASTG-TEST-0212.md
@@ -10,17 +10,19 @@ knowledge: [MASTG-KNOW-0012]
 
 ## Overview
 
-In this test case, we will look for the use of hardcoded keys in Android applications. To do this, we need to focus on the cryptographic implementations of hardcoded keys. The Java Cryptography Architecture (JCA) provides the [`SecretKeySpec`](https://developer.android.com/reference/javax/crypto/spec/SecretKeySpec) class, which allows you to create a [`SecretKey`](https://developer.android.com/reference/javax/crypto/SecretKey) from a byte array.
+In this test case, we will look for the use of hardcoded cryptographic keys in Android applications. Hardcoded key material may be passed to different cryptographic APIs or represented using different key classes and specifications. For example, the Java Cryptography Architecture (JCA) provides several [`KeySpec`](https://developer.android.com/reference/java/security/spec/KeySpec) implementations and key factory APIs for constructing cryptographic keys from supplied key material.
+
+The use of a key-related API or class, such as [`SecretKeySpec`](https://developer.android.com/reference/javax/crypto/spec/SecretKeySpec), does not by itself indicate that a key is hardcoded. The source of the key material must be traced to determine whether it is embedded in the application code.
 
 ## Steps
 
 1. Use @MASTG-TECH-0013 to reverse engineer the app.
-2. Use @MASTG-TECH-0014 to look for the relevant APIs.
+2. Use @MASTG-TECH-0014 to identify cryptographic key construction, import, derivation, or use, and trace the corresponding key material back to its source.
 
 ## Observation
 
-The output should contain a list of locations where hardcoded keys are used.
+The output should contain a list of locations where cryptographic keys are used together with the source of their key material, identifying any key material that is hardcoded in the application code.
 
 ## Evaluation
 
-The test case fails if you find any hardcoded keys that are used in security-sensitive contexts.
+The test case fails if you find any hardcoded cryptographic key material that is used in security-sensitive contexts.


### PR DESCRIPTION
Updated the test case to clarify the focus on hardcoded cryptographic keys and the importance of tracing key material sources. Enhanced steps and observations for better guidance on identifying hardcoded keys.
